### PR TITLE
Error refactor

### DIFF
--- a/benches/io_benchmarking.rs
+++ b/benches/io_benchmarking.rs
@@ -4,15 +4,16 @@ use dmap::formats::{DmapRecord, FitacfRecord, IqdatRecord, MapRecord, RawacfReco
 use std::fs::File;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    // c.bench_function("Read IQDAT", |b| b.iter(|| read_iqdat()));
-    // c.bench_function("Read MAP", |b| b.iter(|| read_map()));
+    c.bench_function("Read IQDAT", |b| b.iter(|| read_iqdat()));
     c.bench_function("Read RAWACF", |b| b.iter(|| read_rawacf()));
-    c.bench_function("Read Full-size RAWACF", |b| {
-        b.iter(|| read_fullsize_rawacf())
-    });
-    c.bench_function("Read Full-size FITACF", |b| {
-        b.iter(|| read_fullsize_fitacf())
-    });
+    c.bench_function("Read FITACF", |b| b.iter(|| read_fitacf()));
+    // c.bench_function("Read MAP", |b| b.iter(|| read_map()));
+    // c.bench_function("Read Full-size RAWACF", |b| {
+    //     b.iter(|| read_fullsize_rawacf())
+    // });
+    // c.bench_function("Read Full-size FITACF", |b| {
+    //     b.iter(|| read_fullsize_fitacf())
+    // });
 
     // let records = read_iqdat();
     // c.bench_with_input(

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,84 @@
+#[derive(Debug)]
+pub enum DmapError {
+    /// Represents an empty source.
+    EmptySource,
+
+    /// Represents a failure to read from input.
+    ReadError { source: std::io::Error },
+
+    /// Represents invalid conditions when reading from input.
+    CorruptDmapError(&'static str),
+
+    /// Represents a failure to intepret data from input.
+    CastError { position: usize, kind: &'static str },
+
+    /// Represents all other cases of `std::io::Error`.
+    IOError(std::io::Error),
+
+    /// Represents an attempt to extract the wrong type of data.
+    ExtractionError,
+
+    /// Represents an invalid key for a DMAP type.
+    KeyError(i8),
+
+    /// Represents a failure to read a DMAP record.
+    RecordError(String),
+
+    /// Represents an invalid scalar field.
+    ScalarError(String),
+
+    /// Represents an invalid vector field.
+    VectorError(String),
+}
+impl std::error::Error for DmapError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            DmapError::ReadError { ref source } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for DmapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            DmapError::EmptySource => {
+                write!(f, "Source contains no data")
+            }
+            DmapError::ReadError { .. } => {
+                write!(f, "Read error")
+            }
+            DmapError::CorruptDmapError(s) => {
+                write!(f, "{s}")
+            }
+            DmapError::CastError {
+                ref position,
+                ref kind,
+            } => {
+                write!(f, "Unable to interpet value at {position:?} as {kind:?}")
+            }
+            DmapError::IOError(ref err) => err.fmt(f),
+            DmapError::ExtractionError => {
+                write!(f, "Extraction error")
+            }
+            DmapError::KeyError(ref key) => {
+                write!(f, "Invalid key '{:?}'", key)
+            }
+            DmapError::RecordError(ref s) => {
+                write!(f, "{s:?}")
+            }
+            DmapError::ScalarError(ref s) => {
+                write!(f, "{s:?}")
+            }
+            DmapError::VectorError(ref s) => {
+                write!(f, "{s:?}")
+            }
+        }
+    }
+}
+
+impl From<std::io::Error> for DmapError {
+    fn from(err: std::io::Error) -> Self {
+        DmapError::IOError(err)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@ pub enum DmapError {
     /// Represents invalid conditions when reading from input.
     CorruptDmapError(&'static str),
 
-    /// Represents a failure to intepret data from input.
+    /// Represents a failure to interpret data from input.
     CastError { position: usize, kind: &'static str },
 
     /// Represents all other cases of `std::io::Error`.
@@ -55,7 +55,7 @@ impl std::fmt::Display for DmapError {
                 ref position,
                 ref kind,
             } => {
-                write!(f, "Unable to interpet value at {position:?} as {kind:?}")
+                write!(f, "Unable to interpret value at {position:?} as {kind:?}")
             }
             DmapError::IOError(ref err) => err.fmt(f),
             DmapError::ExtractionError => {

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -3,23 +3,10 @@ use crate::{
     DmapVec, InDmap, RawDmapScalar, RawDmapVector,
 };
 use std::collections::HashMap;
-use std::error::Error;
-use std::fmt;
 use std::fmt::Display;
 use std::fs::File;
 use std::io::{Cursor, Read, Write};
 use std::path::Path;
-
-#[derive(Debug, Clone)]
-pub struct FileFormatError {
-    details: String,
-}
-impl Error for FileFormatError {}
-impl Display for FileFormatError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.details)
-    }
-}
 
 /// Writes DmapRecords to path as a Vec<u8>
 ///
@@ -70,7 +57,7 @@ pub trait DmapRecord {
         let bytes_already_read = cursor.position();
         let _code = match read_data(cursor, DmapType::INT(0))? {
             DmapType::INT(i) => Ok(i),
-            _ => Err(DmapError::new("PARSE RECORD: Invalid code")),
+            _ => Err(DmapError::CodeError(i)),
         }?;
         let size = match read_data(cursor, DmapType::INT(0))? {
             DmapType::INT(i) => Ok(i),

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -1403,19 +1403,19 @@ pub struct MapRecord {
     model_weight: i16,
     error_weight: i16,
     imf_flag: i16,
-    imf_delay: i16,
-    imf_bx: f64,
-    imf_by: f64,
-    imf_bz: f64,
-    imf_vx: f64,
-    imf_tilt: f64,
-    imf_kp: f64,
+    imf_delay: Option<i16>,      // map_addimf fields
+    imf_bx: Option<f64>,         // map_addimf fields
+    imf_by: Option<f64>,         // map_addimf fields
+    imf_bz: Option<f64>,         // map_addimf fields
+    imf_vx: Option<f64>,         // map_addimf fields
+    imf_tilt: Option<f64>,       // map_addimf fields
+    imf_kp: Option<f64>,         // map_addimf fields
     model_angle: Option<String>, // map_addmodel fields
     model_level: Option<String>, // map_addmodel fields
     model_tilt: Option<String>,  // map_addmodel fields
     model_name: Option<String>,  // map_addmodel fields
     hemisphere: i16,
-    igrf_flag: i16,
+    igrf_flag: Option<i16>,
     fit_order: i16,
     min_latitude: f32,
     chi_squared: f64,
@@ -1499,19 +1499,19 @@ impl DmapRecord for MapRecord {
         let model_weight = get_scalar_val::<i16>(scalars, "model.wt")?;
         let error_weight = get_scalar_val::<i16>(scalars, "error.wt")?;
         let imf_flag = get_scalar_val::<i16>(scalars, "IMF.flag")?;
-        let imf_delay = get_scalar_val::<i16>(scalars, "IMF.delay")?;
-        let imf_bx = get_scalar_val::<f64>(scalars, "IMF.Bx")?;
-        let imf_by = get_scalar_val::<f64>(scalars, "IMF.By")?;
-        let imf_bz = get_scalar_val::<f64>(scalars, "IMF.Bz")?;
-        let imf_vx = get_scalar_val::<f64>(scalars, "IMF.Vx")?;
-        let imf_tilt = get_scalar_val::<f64>(scalars, "IMF.tilt")?;
-        let imf_kp = get_scalar_val::<f64>(scalars, "IMT.Kp")?;
+        let imf_delay = get_scalar_val::<i16>(scalars, "IMF.delay").ok();
+        let imf_bx = get_scalar_val::<f64>(scalars, "IMF.Bx").ok();
+        let imf_by = get_scalar_val::<f64>(scalars, "IMF.By").ok();
+        let imf_bz = get_scalar_val::<f64>(scalars, "IMF.Bz").ok();
+        let imf_vx = get_scalar_val::<f64>(scalars, "IMF.Vx").ok();
+        let imf_tilt = get_scalar_val::<f64>(scalars, "IMF.tilt").ok();
+        let imf_kp = get_scalar_val::<f64>(scalars, "IMT.Kp").ok();
         let model_angle = get_scalar_val::<String>(scalars, "model.angle").ok();
         let model_level = get_scalar_val::<String>(scalars, "model.level").ok();
         let model_tilt = get_scalar_val::<String>(scalars, "model.tilt").ok();
         let model_name = get_scalar_val::<String>(scalars, "model.name").ok();
         let hemisphere = get_scalar_val::<i16>(scalars, "hemisphere")?;
-        let igrf_flag = get_scalar_val::<i16>(scalars, "noigrf")?;
+        let igrf_flag = get_scalar_val::<i16>(scalars, "noigrf").ok();
         let fit_order = get_scalar_val::<i16>(scalars, "fit.order")?;
         let min_latitude = get_scalar_val::<f32>(scalars, "latmin")?;
         let chi_squared = get_scalar_val::<f64>(scalars, "chi.sqr")?;
@@ -1689,13 +1689,34 @@ impl DmapRecord for MapRecord {
         data_bytes.extend(self.model_weight.to_bytes("model.wt"));
         data_bytes.extend(self.error_weight.to_bytes("error.wt"));
         data_bytes.extend(self.imf_flag.to_bytes("IMF.flag"));
-        data_bytes.extend(self.imf_delay.to_bytes("IMF.delay"));
-        data_bytes.extend(self.imf_bx.to_bytes("IMF.Bx"));
-        data_bytes.extend(self.imf_by.to_bytes("IMF.By"));
-        data_bytes.extend(self.imf_bz.to_bytes("IMF.Bz"));
-        data_bytes.extend(self.imf_vx.to_bytes("IMF.Vx"));
-        data_bytes.extend(self.imf_tilt.to_bytes("IMF.tilt"));
-        data_bytes.extend(self.imf_kp.to_bytes("IMF.Kp"));
+        if let Some(x) = &self.imf_delay {
+            data_bytes.extend(x.to_bytes("IMF.delay"));
+            num_scalars += 1;
+        } // map_addimf fields
+        if let Some(x) = &self.imf_bx {
+            data_bytes.extend(x.to_bytes("IMF.Bx"));
+            num_scalars += 1;
+        } // map_addimf fields
+        if let Some(x) = &self.imf_by {
+            data_bytes.extend(x.to_bytes("IMF.By"));
+            num_scalars += 1;
+        } // map_addimf fields
+        if let Some(x) = &self.imf_bz {
+            data_bytes.extend(x.to_bytes("IMF.Bz"));
+            num_scalars += 1;
+        } // map_addimf fields
+        if let Some(x) = &self.imf_vx {
+            data_bytes.extend(x.to_bytes("IMF.Vx"));
+            num_scalars += 1;
+        } // map_addimf fields
+        if let Some(x) = &self.imf_tilt {
+            data_bytes.extend(x.to_bytes("IMF.tilt"));
+            num_scalars += 1;
+        } // map_addimf fields
+        if let Some(x) = &self.imf_kp {
+            data_bytes.extend(x.to_bytes("IMF.Kp"));
+            num_scalars += 1;
+        } // map_addimf fields
         if let Some(x) = &self.model_angle {
             data_bytes.extend(x.to_bytes("model.angle"));
             num_scalars += 1;
@@ -1713,7 +1734,10 @@ impl DmapRecord for MapRecord {
             num_scalars += 1;
         } // map_addmodel fields
         data_bytes.extend(self.hemisphere.to_bytes("hemisphere"));
-        data_bytes.extend(self.igrf_flag.to_bytes("noigrf"));
+        if let Some(x) = &self.igrf_flag {
+            data_bytes.extend(x.to_bytes("noigrf"));
+            num_scalars += 1;
+        }
         data_bytes.extend(self.fit_order.to_bytes("fit.order"));
         data_bytes.extend(self.min_latitude.to_bytes("latmin"));
         data_bytes.extend(self.chi_squared.to_bytes("chi.sqr"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,94 +1,11 @@
+pub mod error;
 pub mod formats;
 
+use crate::error::DmapError;
 use std::collections::HashMap;
 use std::io::Cursor;
 
 type Result<T> = std::result::Result<T, DmapError>;
-
-#[derive(Debug)]
-pub enum DmapError {
-    /// Represents an empty source.
-    EmptySource,
-
-    /// Represents a failure to read from input.
-    ReadError { source: std::io::Error },
-
-    /// Represents invalid conditions when reading from input.
-    CorruptDmapError(&'static str),
-
-    /// Represents a failure to intepret data from input.
-    CastError { position: usize, kind: &'static str },
-
-    /// Represents all other cases of `std::io::Error`.
-    IOError(std::io::Error),
-
-    /// Represents an attempt to extract the wrong type of data.
-    ExtractionError,
-
-    /// Represents an invalid key for a DMAP type.
-    KeyError(i8),
-
-    /// Represents a failure to read a DMAP record.
-    RecordError(String),
-
-    /// Represents an invalid scalar field.
-    ScalarError(String),
-
-    /// Represents an invalid vector field.
-    VectorError(String),
-}
-impl std::error::Error for DmapError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match *self {
-            DmapError::ReadError { ref source } => Some(source),
-            _ => None,
-        }
-    }
-}
-
-impl std::fmt::Display for DmapError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match *self {
-            DmapError::EmptySource => {
-                write!(f, "Source contains no data")
-            }
-            DmapError::ReadError { .. } => {
-                write!(f, "Read error")
-            }
-            DmapError::CorruptDmapError(s) => {
-                write!(f, "{s}")
-            }
-            DmapError::CastError {
-                ref position,
-                ref kind,
-            } => {
-                write!(f, "Unable to interpet value at {position:?} as {kind:?}")
-            }
-            DmapError::IOError(ref err) => err.fmt(f),
-            DmapError::ExtractionError => {
-                write!(f, "Extraction error")
-            }
-            DmapError::KeyError(ref key) => {
-                write!(f, "Invalid key '{:?}'", key)
-            }
-            DmapError::RecordError(ref s) => {
-                write!(f, "{s:?}")
-            }
-            DmapError::ScalarError(ref s) => {
-                write!(f, "{s:?}")
-            }
-            DmapError::VectorError(ref s) => {
-                write!(f, "{s:?}")
-            }
-        }
-    }
-}
-
-impl From<std::io::Error> for DmapError {
-    fn from(err: std::io::Error) -> Self {
-        DmapError::IOError(err)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 // }
 
 #[test]
-fn test_read_write_iqdat() {
+fn read_write_iqdat() {
     let file = File::open(Path::new("tests/test_files/test.iqdat")).expect("test file not found");
     let contents = IqdatRecord::read_records(file).expect("unable to read test file contents");
 
@@ -35,7 +35,7 @@ fn test_read_write_iqdat() {
 }
 
 #[test]
-fn test_read_write_rawacf() {
+fn read_write_rawacf() {
     let file = File::open(Path::new("tests/test_files/test.rawacf")).expect("test file not found");
     let contents = RawacfRecord::read_records(file).expect("unable to read test file contents");
     println!("{:?}", contents[0].xcfs);
@@ -52,7 +52,7 @@ fn test_read_write_rawacf() {
 }
 
 #[test]
-fn test_read_write_fitacf() {
+fn read_write_fitacf() {
     let file = File::open(Path::new("tests/test_files/test.fitacf")).expect("test file not found");
     let contents = FitacfRecord::read_records(file).expect("unable to read test file contents");
 
@@ -67,7 +67,7 @@ fn test_read_write_fitacf() {
 }
 
 #[test]
-fn test_read_write_map() {
+fn read_write_map() {
     let file = File::open(Path::new("tests/test_files/test.map")).expect("test file not found");
     let contents = MapRecord::read_records(file).expect("unable to read test file contents");
 


### PR DESCRIPTION
Refactored the DmapError class to implement std::error::Error and more clearly report the various errors that can be encountered when parsing a DMAP record.