### PR TITLE
Updated file permissions for writing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dmap"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "darn-dmap"
-version = "0.1.3"
+version = "0.1.4"
 requires-python = ">=3.8"
 authors = [
     { name = "Remington Rohel" }

--- a/src/formats/dmap.rs
+++ b/src/formats/dmap.rs
@@ -2,16 +2,16 @@
 //! DMAP record types must have. Also defines the `GenericRecord` struct which
 //! implements `Record`, which can be used for reading/writing DMAP files without
 //! checking that certain fields are or are not present, or have a given type.
-use std::ffi::OsStr;
 use crate::error::DmapError;
 use crate::types::{parse_scalar, parse_vector, read_data, DmapField, DmapType, DmapVec, Fields};
+use bzip2::read::BzDecoder;
 use indexmap::IndexMap;
 use rayon::prelude::*;
+use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::{Cursor, Read};
 use std::path::PathBuf;
-use bzip2::read::BzDecoder;
 
 pub trait Record: Debug {
     /// Reads from dmap_data and parses into a collection of Records.
@@ -66,7 +66,7 @@ pub trait Record: Debug {
                 let compressor = BzDecoder::new(file);
                 Self::read_records(compressor)
             }
-            _ => { Self::read_records(file) }
+            _ => Self::read_records(file),
         }
     }
 
@@ -439,7 +439,6 @@ pub trait Record: Debug {
         Ok((num_scalars, num_vectors, data_bytes))
     }
 }
-
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct GenericRecord {

--- a/src/formats/grid.rs
+++ b/src/formats/grid.rs
@@ -56,7 +56,7 @@ static VECTOR_FIELDS_OPT: [(&str, Type); 13] = [
     ("vector.pwr.sd", Type::Float),
     ("vector.wdt.median", Type::Float),
     ("vector.wdt.sd", Type::Float),
-    ("vector.srng", Type::Float)
+    ("vector.srng", Type::Float),
 ];
 
 lazy_static! {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,10 +5,10 @@ use dmap::formats::iqdat::IqdatRecord;
 use dmap::formats::map::MapRecord;
 use dmap::formats::rawacf::RawacfRecord;
 use dmap::formats::snd::SndRecord;
+use dmap::{write_dmap, write_fitacf, write_grid, write_iqdat, write_map, write_rawacf, write_snd};
 use itertools::izip;
 use std::fs::remove_file;
 use std::path::PathBuf;
-use dmap::{write_iqdat, write_rawacf, write_fitacf, write_grid, write_map, write_snd, write_dmap};
 
 #[test]
 fn read_write_generic() {


### PR DESCRIPTION
* .bz2 files are opened with `write` and `create_new` (fails if already exists)
* non-.bz2 files are opened with `append` and `create`

Additionally, ran `cargo fmt` and bumped version to match main branch

