### PR TITLE
Release v0.1.5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --zig
-          sccache: 'true'
+#          sccache: 'true'
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -79,7 +79,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
-          sccache: 'true'
+#          sccache: 'true'
           manylinux: musllinux_1_2
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -108,7 +108,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
-          sccache: 'true'
+#          sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -135,7 +135,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
-          sccache: 'true'
+#          sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,6 +57,7 @@ jobs:
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
+    if: "startsWith(github.ref, 'refs/tags/')"
     strategy:
       matrix:
         platform:
@@ -88,6 +89,7 @@ jobs:
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
+    if: "startsWith(github.ref, 'refs/tags/')"
     strategy:
       matrix:
         platform:
@@ -115,6 +117,7 @@ jobs:
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
+    if: "startsWith(github.ref, 'refs/tags/')"
     strategy:
       matrix:
         platform:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dmap"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "darn-dmap"
-version = "0.1.4"
+version = "0.1.5"
 requires-python = ">=3.8"
 authors = [
     { name = "Remington Rohel" }

--- a/src/formats/dmap.rs
+++ b/src/formats/dmap.rs
@@ -442,7 +442,7 @@ pub trait Record: Debug {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct GenericRecord {
-    pub(crate) data: IndexMap<String, DmapField>,
+    pub data: IndexMap<String, DmapField>,
 }
 
 impl Record for GenericRecord {

--- a/src/formats/dmap.rs
+++ b/src/formats/dmap.rs
@@ -445,6 +445,15 @@ pub struct GenericRecord {
     pub data: IndexMap<String, DmapField>,
 }
 
+impl GenericRecord {
+    pub fn get(&self, key: &String) -> Option<&DmapField> {
+        self.data.get(key)
+    }
+    pub fn keys(&self) -> Vec<&String> {
+        self.data.keys().collect()
+    }
+}
+
 impl Record for GenericRecord {
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<GenericRecord, DmapError> {
         Ok(GenericRecord {

--- a/src/formats/fitacf.rs
+++ b/src/formats/fitacf.rs
@@ -192,7 +192,11 @@ impl FitacfRecord {
         self.data.keys().collect()
     }
 }
-impl Record for FitacfRecord {
+impl Record<'_> for FitacfRecord {
+    fn inner(self) -> IndexMap<String, DmapField> {
+        self.data
+    }
+
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<FitacfRecord, DmapError> {
         match Self::check_fields(fields, &FITACF_FIELDS) {
             Ok(_) => {}
@@ -221,6 +225,6 @@ impl TryFrom<&mut IndexMap<String, DmapField>> for FitacfRecord {
     type Error = DmapError;
 
     fn try_from(value: &mut IndexMap<String, DmapField>) -> Result<Self, Self::Error> {
-        Ok(Self::coerce::<FitacfRecord>(value, &FITACF_FIELDS)?)
+        Self::coerce::<FitacfRecord>(value, &FITACF_FIELDS)
     }
 }

--- a/src/formats/fitacf.rs
+++ b/src/formats/fitacf.rs
@@ -184,6 +184,14 @@ pub struct FitacfRecord {
     pub data: IndexMap<String, DmapField>,
 }
 
+impl FitacfRecord {
+    pub fn get(&self, key: &String) -> Option<&DmapField> {
+        self.data.get(key)
+    }
+    pub fn keys(&self) -> Vec<&String> {
+        self.data.keys().collect()
+    }
+}
 impl Record for FitacfRecord {
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<FitacfRecord, DmapError> {
         match Self::check_fields(fields, &FITACF_FIELDS) {

--- a/src/formats/fitacf.rs
+++ b/src/formats/fitacf.rs
@@ -181,7 +181,7 @@ lazy_static! {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct FitacfRecord {
-    pub(crate) data: IndexMap<String, DmapField>,
+    pub data: IndexMap<String, DmapField>,
 }
 
 impl Record for FitacfRecord {

--- a/src/formats/grid.rs
+++ b/src/formats/grid.rs
@@ -115,7 +115,7 @@ lazy_static! {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct GridRecord {
-    pub(crate) data: IndexMap<String, DmapField>,
+    pub data: IndexMap<String, DmapField>,
 }
 
 impl Record for GridRecord {

--- a/src/formats/grid.rs
+++ b/src/formats/grid.rs
@@ -113,6 +113,7 @@ lazy_static! {
     };
 }
 
+/// Struct containing the checked fields of a single GRID record.
 #[derive(Debug, PartialEq, Clone)]
 pub struct GridRecord {
     pub data: IndexMap<String, DmapField>,
@@ -127,7 +128,11 @@ impl GridRecord {
     }
 }
 
-impl Record for GridRecord {
+impl Record<'_> for GridRecord {
+    fn inner(self) -> IndexMap<String, DmapField> {
+        self.data
+    }
+
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<GridRecord, DmapError> {
         match Self::check_fields(fields, &GRID_FIELDS) {
             Ok(_) => {}
@@ -156,6 +161,6 @@ impl TryFrom<&mut IndexMap<String, DmapField>> for GridRecord {
     type Error = DmapError;
 
     fn try_from(value: &mut IndexMap<String, DmapField>) -> Result<Self, Self::Error> {
-        Ok(Self::coerce::<GridRecord>(value, &GRID_FIELDS)?)
+        Self::coerce::<GridRecord>(value, &GRID_FIELDS)
     }
 }

--- a/src/formats/grid.rs
+++ b/src/formats/grid.rs
@@ -118,6 +118,15 @@ pub struct GridRecord {
     pub data: IndexMap<String, DmapField>,
 }
 
+impl GridRecord {
+    pub fn get(&self, key: &String) -> Option<&DmapField> {
+        self.data.get(key)
+    }
+    pub fn keys(&self) -> Vec<&String> {
+        self.data.keys().collect()
+    }
+}
+
 impl Record for GridRecord {
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<GridRecord, DmapError> {
         match Self::check_fields(fields, &GRID_FIELDS) {

--- a/src/formats/iqdat.rs
+++ b/src/formats/iqdat.rs
@@ -109,7 +109,11 @@ impl IqdatRecord {
     }
 }
 
-impl Record for IqdatRecord {
+impl Record<'_> for IqdatRecord {
+    fn inner(self) -> IndexMap<String, DmapField> {
+        self.data
+    }
+
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<IqdatRecord, DmapError> {
         match Self::check_fields(fields, &IQDAT_FIELDS) {
             Ok(_) => {}
@@ -138,6 +142,6 @@ impl TryFrom<&mut IndexMap<String, DmapField>> for IqdatRecord {
     type Error = DmapError;
 
     fn try_from(value: &mut IndexMap<String, DmapField>) -> Result<Self, Self::Error> {
-        Ok(Self::coerce::<IqdatRecord>(value, &IQDAT_FIELDS)?)
+        Self::coerce::<IqdatRecord>(value, &IQDAT_FIELDS)
     }
 }

--- a/src/formats/iqdat.rs
+++ b/src/formats/iqdat.rs
@@ -100,6 +100,15 @@ pub struct IqdatRecord {
     pub data: IndexMap<String, DmapField>,
 }
 
+impl IqdatRecord {
+    pub fn get(&self, key: &String) -> Option<&DmapField> {
+        self.data.get(key)
+    }
+    pub fn keys(&self) -> Vec<&String> {
+        self.data.keys().collect()
+    }
+}
+
 impl Record for IqdatRecord {
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<IqdatRecord, DmapError> {
         match Self::check_fields(fields, &IQDAT_FIELDS) {

--- a/src/formats/iqdat.rs
+++ b/src/formats/iqdat.rs
@@ -97,7 +97,7 @@ lazy_static! {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct IqdatRecord {
-    pub(crate) data: IndexMap<String, DmapField>,
+    pub data: IndexMap<String, DmapField>,
 }
 
 impl Record for IqdatRecord {

--- a/src/formats/map.rs
+++ b/src/formats/map.rs
@@ -181,7 +181,11 @@ impl MapRecord {
     }
 }
 
-impl Record for MapRecord {
+impl Record<'_> for MapRecord {
+    fn inner(self) -> IndexMap<String, DmapField> {
+        self.data
+    }
+
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<MapRecord, DmapError> {
         match Self::check_fields(fields, &MAP_FIELDS) {
             Ok(_) => {}
@@ -210,6 +214,6 @@ impl TryFrom<&mut IndexMap<String, DmapField>> for MapRecord {
     type Error = DmapError;
 
     fn try_from(value: &mut IndexMap<String, DmapField>) -> Result<Self, Self::Error> {
-        Ok(Self::coerce::<MapRecord>(value, &MAP_FIELDS)?)
+        Self::coerce::<MapRecord>(value, &MAP_FIELDS)
     }
 }

--- a/src/formats/map.rs
+++ b/src/formats/map.rs
@@ -172,6 +172,15 @@ pub struct MapRecord {
     pub data: IndexMap<String, DmapField>,
 }
 
+impl MapRecord {
+    pub fn get(&self, key: &String) -> Option<&DmapField> {
+        self.data.get(key)
+    }
+    pub fn keys(&self) -> Vec<&String> {
+        self.data.keys().collect()
+    }
+}
+
 impl Record for MapRecord {
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<MapRecord, DmapError> {
         match Self::check_fields(fields, &MAP_FIELDS) {

--- a/src/formats/map.rs
+++ b/src/formats/map.rs
@@ -169,7 +169,7 @@ lazy_static! {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct MapRecord {
-    pub(crate) data: IndexMap<String, DmapField>,
+    pub data: IndexMap<String, DmapField>,
 }
 
 impl Record for MapRecord {

--- a/src/formats/rawacf.rs
+++ b/src/formats/rawacf.rs
@@ -84,21 +84,28 @@ lazy_static! {
     };
 }
 
+/// Struct containing the checked fields of a single RAWACF record.
 #[derive(Debug, PartialEq, Clone)]
 pub struct RawacfRecord {
     pub data: IndexMap<String, DmapField>,
 }
 
 impl RawacfRecord {
+    /// Returns the field with name `key`, if it exists in the record.
     pub fn get(&self, key: &String) -> Option<&DmapField> {
         self.data.get(key)
     }
+
+    /// Returns the names of all fields stored in the record.
     pub fn keys(&self) -> Vec<&String> {
         self.data.keys().collect()
     }
 }
 
-impl Record for RawacfRecord {
+impl Record<'_> for RawacfRecord {
+    fn inner(self) -> IndexMap<String, DmapField> {
+        self.data
+    }
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<RawacfRecord, DmapError> {
         match Self::check_fields(fields, &RAWACF_FIELDS) {
             Ok(_) => {}
@@ -127,6 +134,6 @@ impl TryFrom<&mut IndexMap<String, DmapField>> for RawacfRecord {
     type Error = DmapError;
 
     fn try_from(value: &mut IndexMap<String, DmapField>) -> Result<Self, Self::Error> {
-        Ok(Self::coerce::<RawacfRecord>(value, &RAWACF_FIELDS)?)
+        Self::coerce::<RawacfRecord>(value, &RAWACF_FIELDS)
     }
 }

--- a/src/formats/rawacf.rs
+++ b/src/formats/rawacf.rs
@@ -86,7 +86,7 @@ lazy_static! {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct RawacfRecord {
-    pub(crate) data: IndexMap<String, DmapField>,
+    pub data: IndexMap<String, DmapField>,
 }
 
 impl Record for RawacfRecord {

--- a/src/formats/rawacf.rs
+++ b/src/formats/rawacf.rs
@@ -89,6 +89,15 @@ pub struct RawacfRecord {
     pub data: IndexMap<String, DmapField>,
 }
 
+impl RawacfRecord {
+    pub fn get(&self, key: &String) -> Option<&DmapField> {
+        self.data.get(key)
+    }
+    pub fn keys(&self) -> Vec<&String> {
+        self.data.keys().collect()
+    }
+}
+
 impl Record for RawacfRecord {
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<RawacfRecord, DmapError> {
         match Self::check_fields(fields, &RAWACF_FIELDS) {

--- a/src/formats/snd.rs
+++ b/src/formats/snd.rs
@@ -97,7 +97,11 @@ impl SndRecord {
         self.data.keys().collect()
     }
 }
-impl Record for SndRecord {
+impl Record<'_> for SndRecord {
+    fn inner(self) -> IndexMap<String, DmapField> {
+        self.data
+    }
+
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<SndRecord, DmapError> {
         match Self::check_fields(fields, &SND_FIELDS) {
             Ok(_) => {}
@@ -126,6 +130,6 @@ impl TryFrom<&mut IndexMap<String, DmapField>> for SndRecord {
     type Error = DmapError;
 
     fn try_from(value: &mut IndexMap<String, DmapField>) -> Result<Self, Self::Error> {
-        Ok(Self::coerce::<SndRecord>(value, &SND_FIELDS)?)
+        Self::coerce::<SndRecord>(value, &SND_FIELDS)
     }
 }

--- a/src/formats/snd.rs
+++ b/src/formats/snd.rs
@@ -86,7 +86,7 @@ lazy_static! {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct SndRecord {
-    pub(crate) data: IndexMap<String, DmapField>,
+    pub data: IndexMap<String, DmapField>,
 }
 
 impl Record for SndRecord {

--- a/src/formats/snd.rs
+++ b/src/formats/snd.rs
@@ -89,6 +89,14 @@ pub struct SndRecord {
     pub data: IndexMap<String, DmapField>,
 }
 
+impl SndRecord {
+    pub fn get(&self, key: &String) -> Option<&DmapField> {
+        self.data.get(key)
+    }
+    pub fn keys(&self) -> Vec<&String> {
+        self.data.keys().collect()
+    }
+}
 impl Record for SndRecord {
     fn new(fields: &mut IndexMap<String, DmapField>) -> Result<SndRecord, DmapError> {
         match Self::check_fields(fields, &SND_FIELDS) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,19 +36,14 @@ use std::path::PathBuf;
 /// opened in `create_new` mode, meaning it will fail if a file already exists at the given path.
 fn write_to_file(bytes: Vec<u8>, outfile: &PathBuf) -> Result<(), std::io::Error> {
     let mut out_bytes: Vec<u8> = vec![];
-    let mut file: File;
+    let mut file: File = OpenOptions::new().append(true).create(true).open(outfile)?;
     match outfile.extension() {
         Some(ext) if ext == OsStr::new("bz2") => {
             let mut compressor = BzEncoder::new(bytes.as_slice(), Compression::best());
             compressor.read_to_end(&mut out_bytes)?;
-            file = OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(outfile)?;
         }
         _ => {
             out_bytes = bytes;
-            file = OpenOptions::new().append(true).create(true).open(outfile)?;
         }
     }
     file.write_all(&out_bytes)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ use pyo3::prelude::*;
 use rayon::iter::Either;
 use rayon::prelude::*;
 use std::ffi::OsStr;
+use std::fmt::Debug;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -49,8 +50,8 @@ fn write_to_file(bytes: Vec<u8>, outfile: &PathBuf) -> Result<(), std::io::Error
     file.write_all(&out_bytes)
 }
 
-/// Write generic DMAP to `outfile`
-pub fn write_dmap(mut recs: Vec<GenericRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
+/// Writes a collection of `impl Record`s to `outfile`
+fn write_generic<'a>(mut recs: Vec<impl Record<'a>>, outfile: &PathBuf) -> Result<(), DmapError> {
     let mut bytes: Vec<u8> = vec![];
     let (errors, rec_bytes): (Vec<_>, Vec<_>) =
         recs.par_iter_mut()
@@ -59,7 +60,7 @@ pub fn write_dmap(mut recs: Vec<GenericRecord>, outfile: &PathBuf) -> Result<(),
                 Err(e) => Either::Left((i, e)),
                 Ok(y) => Either::Right(y),
             });
-    if errors.len() > 0 {
+    if !errors.is_empty() {
         Err(DmapError::InvalidRecord(format!(
             "Corrupted records: {errors:?}"
         )))?
@@ -69,273 +70,61 @@ pub fn write_dmap(mut recs: Vec<GenericRecord>, outfile: &PathBuf) -> Result<(),
     Ok(())
 }
 
-/// Attempts to convert `recs` to `GenericRecord` then write to `outfile`.
-pub fn try_write_dmap(
-    mut recs: Vec<IndexMap<String, DmapField>>,
-    outfile: &PathBuf,
-) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut().enumerate().partition_map(|(i, rec)| {
-            match GenericRecord::try_from(rec) {
-                Err(e) => Either::Left((i, e)),
-                Ok(x) => match x.to_bytes() {
-                    Err(e) => Either::Left((i, e)),
-                    Ok(y) => Either::Right(y),
-                },
-            }
-        });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
-    }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
+/// Write generic DMAP to `outfile`
+pub fn write_dmap(recs: Vec<GenericRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
+    write_generic(recs, outfile)
 }
 
 /// Write IQDAT records to `outfile`.
-pub fn write_iqdat(mut recs: Vec<IqdatRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut()
-            .enumerate()
-            .partition_map(|(i, rec)| match rec.to_bytes() {
-                Err(e) => Either::Left((i, e)),
-                Ok(y) => Either::Right(y),
-            });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
-    }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
-}
-
-/// Attempts to convert `recs` to `IqdatRecord` then write to `outfile`.
-pub fn try_write_iqdat(
-    mut recs: Vec<IndexMap<String, DmapField>>,
-    outfile: &PathBuf,
-) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut().enumerate().partition_map(|(i, rec)| {
-            match IqdatRecord::try_from(rec) {
-                Err(e) => Either::Left((i, e)),
-                Ok(x) => match x.to_bytes() {
-                    Err(e) => Either::Left((i, e)),
-                    Ok(y) => Either::Right(y),
-                },
-            }
-        });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
-    }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
+pub fn write_iqdat(recs: Vec<IqdatRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
+    write_generic(recs, outfile)
 }
 
 /// Write RAWACF records to `outfile`.
-pub fn write_rawacf(mut recs: Vec<RawacfRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut()
-            .enumerate()
-            .partition_map(|(i, rec)| match rec.to_bytes() {
-                Err(e) => Either::Left((i, e)),
-                Ok(y) => Either::Right(y),
-            });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
-    }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
-}
-
-/// Attempts to convert `recs` to `RawacfRecord` then write to `outfile`.
-pub fn try_write_rawacf(
-    mut recs: Vec<IndexMap<String, DmapField>>,
-    outfile: &PathBuf,
-) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut().enumerate().partition_map(|(i, rec)| {
-            match RawacfRecord::try_from(rec) {
-                Err(e) => Either::Left((i, e)),
-                Ok(x) => match x.to_bytes() {
-                    Err(e) => Either::Left((i, e)),
-                    Ok(y) => Either::Right(y),
-                },
-            }
-        });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
-    }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
+pub fn write_rawacf(recs: Vec<RawacfRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
+    write_generic(recs, outfile)
 }
 
 /// Write FITACF records to `outfile`.
-pub fn write_fitacf(mut recs: Vec<FitacfRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut()
-            .enumerate()
-            .partition_map(|(i, rec)| match rec.to_bytes() {
-                Err(e) => Either::Left((i, e)),
-                Ok(y) => Either::Right(y),
-            });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
-    }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
-}
-
-/// Attempts to convert `recs` to `FitacfRecord` then write to `outfile`.
-pub fn try_write_fitacf(
-    mut recs: Vec<IndexMap<String, DmapField>>,
-    outfile: &PathBuf,
-) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut().enumerate().partition_map(|(i, rec)| {
-            match FitacfRecord::try_from(rec) {
-                Err(e) => Either::Left((i, e)),
-                Ok(x) => match x.to_bytes() {
-                    Err(e) => Either::Left((i, e)),
-                    Ok(y) => Either::Right(y),
-                },
-            }
-        });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
-    }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
+pub fn write_fitacf(recs: Vec<FitacfRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
+    write_generic(recs, outfile)
 }
 
 /// Write GRID records to `outfile`.
-pub fn write_grid(mut recs: Vec<GridRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut()
-            .enumerate()
-            .partition_map(|(i, rec)| match rec.to_bytes() {
-                Err(e) => Either::Left((i, e)),
-                Ok(y) => Either::Right(y),
-            });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
-    }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
-}
-
-/// Attempts to convert `recs` to `GridRecord` then write to `outfile`.
-pub fn try_write_grid(
-    mut recs: Vec<IndexMap<String, DmapField>>,
-    outfile: &PathBuf,
-) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut()
-            .enumerate()
-            .partition_map(|(i, rec)| match GridRecord::try_from(rec) {
-                Err(e) => Either::Left((i, e)),
-                Ok(x) => match x.to_bytes() {
-                    Err(e) => Either::Left((i, e)),
-                    Ok(y) => Either::Right(y),
-                },
-            });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
-    }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
+pub fn write_grid(recs: Vec<GridRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
+    write_generic(recs, outfile)
 }
 
 /// Write MAP records to `outfile`.
-pub fn write_map(mut recs: Vec<MapRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut()
-            .enumerate()
-            .partition_map(|(i, rec)| match rec.to_bytes() {
-                Err(e) => Either::Left((i, e)),
-                Ok(y) => Either::Right(y),
-            });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
-    }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
-}
-
-/// Attempts to convert `recs` to `MapRecord` then write to `outfile`.
-pub fn try_write_map(
-    mut recs: Vec<IndexMap<String, DmapField>>,
-    outfile: &PathBuf,
-) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut()
-            .enumerate()
-            .partition_map(|(i, rec)| match MapRecord::try_from(rec) {
-                Err(e) => Either::Left((i, e)),
-                Ok(x) => match x.to_bytes() {
-                    Err(e) => Either::Left((i, e)),
-                    Ok(y) => Either::Right(y),
-                },
-            });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
-    }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
+pub fn write_map(recs: Vec<MapRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
+    write_generic(recs, outfile)
 }
 
 /// Write SND records to `outfile`.
-pub fn write_snd(mut recs: Vec<SndRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
+pub fn write_snd(recs: Vec<SndRecord>, outfile: &PathBuf) -> Result<(), DmapError> {
+    write_generic(recs, outfile)
+}
+
+/// Attempts to convert `recs` to `T` then append to `outfile`.
+fn try_write_generic<T: for<'a> Record<'a>>(
+    mut recs: Vec<IndexMap<String, DmapField>>,
+    outfile: &PathBuf,
+) -> Result<(), DmapError>
+where
+    for<'a> <T as TryFrom<&'a mut IndexMap<String, DmapField>>>::Error: Send + Debug,
+{
     let mut bytes: Vec<u8> = vec![];
     let (errors, rec_bytes): (Vec<_>, Vec<_>) =
         recs.par_iter_mut()
             .enumerate()
-            .partition_map(|(i, rec)| match rec.to_bytes() {
+            .partition_map(|(i, rec)| match T::try_from(rec) {
                 Err(e) => Either::Left((i, e)),
-                Ok(y) => Either::Right(y),
+                Ok(x) => match x.to_bytes() {
+                    Err(e) => Either::Left((i, e)),
+                    Ok(y) => Either::Right(y),
+                },
             });
-    if errors.len() > 0 {
+    if !errors.is_empty() {
         Err(DmapError::InvalidRecord(format!(
             "Corrupted records: {errors:?}"
         )))?
@@ -345,30 +134,108 @@ pub fn write_snd(mut recs: Vec<SndRecord>, outfile: &PathBuf) -> Result<(), Dmap
     Ok(())
 }
 
-/// Attempts to convert `recs` to `SndRecord` then write to `outfile`.
-pub fn try_write_snd(
-    mut recs: Vec<IndexMap<String, DmapField>>,
+/// Attempts to convert `recs` to `GenericRecord` then append to `outfile`.
+pub fn try_write_dmap(
+    recs: Vec<IndexMap<String, DmapField>>,
     outfile: &PathBuf,
 ) -> Result<(), DmapError> {
-    let mut bytes: Vec<u8> = vec![];
-    let (errors, rec_bytes): (Vec<_>, Vec<_>) =
-        recs.par_iter_mut()
-            .enumerate()
-            .partition_map(|(i, rec)| match SndRecord::try_from(rec) {
-                Err(e) => Either::Left((i, e)),
-                Ok(x) => match x.to_bytes() {
-                    Err(e) => Either::Left((i, e)),
-                    Ok(y) => Either::Right(y),
-                },
-            });
-    if errors.len() > 0 {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
+    try_write_generic::<GenericRecord>(recs, outfile)
+}
+
+/// Attempts to convert `recs` to `IqdatRecord` then append to `outfile`.
+pub fn try_write_iqdat(
+    recs: Vec<IndexMap<String, DmapField>>,
+    outfile: &PathBuf,
+) -> Result<(), DmapError> {
+    try_write_generic::<IqdatRecord>(recs, outfile)
+}
+
+/// Attempts to convert `recs` to `RawacfRecord` then append to `outfile`.
+pub fn try_write_rawacf(
+    recs: Vec<IndexMap<String, DmapField>>,
+    outfile: &PathBuf,
+) -> Result<(), DmapError> {
+    try_write_generic::<RawacfRecord>(recs, outfile)
+}
+
+/// Attempts to convert `recs` to `FitacfRecord` then append to `outfile`.
+pub fn try_write_fitacf(
+    recs: Vec<IndexMap<String, DmapField>>,
+    outfile: &PathBuf,
+) -> Result<(), DmapError> {
+    try_write_generic::<FitacfRecord>(recs, outfile)
+}
+
+/// Attempts to convert `recs` to `GridRecord` then append to `outfile`.
+pub fn try_write_grid(
+    recs: Vec<IndexMap<String, DmapField>>,
+    outfile: &PathBuf,
+) -> Result<(), DmapError> {
+    try_write_generic::<GridRecord>(recs, outfile)
+}
+
+/// Attempts to convert `recs` to `MapRecord` then append to `outfile`.
+pub fn try_write_map(
+    recs: Vec<IndexMap<String, DmapField>>,
+    outfile: &PathBuf,
+) -> Result<(), DmapError> {
+    try_write_generic::<MapRecord>(recs, outfile)
+}
+
+/// Attempts to convert `recs` to `SndRecord` then append to `outfile`.
+pub fn try_write_snd(
+    recs: Vec<IndexMap<String, DmapField>>,
+    outfile: &PathBuf,
+) -> Result<(), DmapError> {
+    try_write_generic::<SndRecord>(recs, outfile)
+}
+
+/// Read in a DMAP file
+pub fn read_dmap(infile: PathBuf) -> Result<Vec<GenericRecord>, DmapError> {
+    GenericRecord::read_file(&infile)
+}
+
+/// Read in an IQDAT file
+pub fn read_iqdat(infile: PathBuf) -> Result<Vec<IqdatRecord>, DmapError> {
+    IqdatRecord::read_file(&infile)
+}
+
+/// Read in a RAWACF file
+pub fn read_rawacf(infile: PathBuf) -> Result<Vec<RawacfRecord>, DmapError> {
+    RawacfRecord::read_file(&infile)
+}
+
+/// Read in a FITACF file
+pub fn read_fitacf(infile: PathBuf) -> Result<Vec<FitacfRecord>, DmapError> {
+    FitacfRecord::read_file(&infile)
+}
+
+/// Read in a GRID file
+pub fn read_grid(infile: PathBuf) -> Result<Vec<GridRecord>, DmapError> {
+    GridRecord::read_file(&infile)
+}
+
+/// Read in a MAP file
+pub fn read_map(infile: PathBuf) -> Result<Vec<MapRecord>, DmapError> {
+    MapRecord::read_file(&infile)
+}
+
+/// Read in an SND file
+pub fn read_snd(infile: PathBuf) -> Result<Vec<SndRecord>, DmapError> {
+    SndRecord::read_file(&infile)
+}
+
+/// Reads the data from infile into a collection of `IndexMap`s
+fn read_generic<T: for<'a> Record<'a> + Send>(
+    infile: PathBuf,
+) -> Result<Vec<IndexMap<String, DmapField>>, DmapError> {
+    match T::read_file(&infile) {
+        Ok(recs) => {
+            let new_recs = recs.into_iter().map(|rec| rec.inner()).collect();
+            Ok(new_recs)
+        }
+        Err(e) => Err(e),
     }
-    bytes.par_extend(rec_bytes.into_par_iter().flatten());
-    write_to_file(bytes, outfile)?;
-    Ok(())
 }
 
 /// Reads a generic DMAP file, returning a list of dictionaries containing the fields.
@@ -376,13 +243,7 @@ pub fn try_write_snd(
 #[pyo3(name = "read_dmap")]
 #[pyo3(text_signature = "(infile: str, /)")]
 fn read_dmap_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>> {
-    match GenericRecord::read_file(&infile) {
-        Ok(recs) => {
-            let new_recs = recs.into_iter().map(|rec| rec.data).collect();
-            Ok(new_recs)
-        }
-        Err(e) => Err(PyErr::from(e)),
-    }
+    read_generic::<GenericRecord>(infile).map_err(PyErr::from)
 }
 
 /// Reads an IQDAT file, returning a list of dictionaries containing the fields.
@@ -390,13 +251,7 @@ fn read_dmap_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>> {
 #[pyo3(name = "read_iqdat")]
 #[pyo3(text_signature = "(infile: str, /)")]
 fn read_iqdat_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>> {
-    match IqdatRecord::read_file(&infile) {
-        Ok(recs) => {
-            let new_recs = recs.into_iter().map(|rec| rec.data).collect();
-            Ok(new_recs)
-        }
-        Err(e) => Err(PyErr::from(e)),
-    }
+    read_generic::<IqdatRecord>(infile).map_err(PyErr::from)
 }
 
 /// Reads a RAWACF file, returning a list of dictionaries containing the fields.
@@ -404,13 +259,7 @@ fn read_iqdat_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>> 
 #[pyo3(name = "read_rawacf")]
 #[pyo3(text_signature = "(infile: str, /)")]
 fn read_rawacf_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>> {
-    match RawacfRecord::read_file(&infile) {
-        Ok(recs) => {
-            let new_recs = recs.into_iter().map(|rec| rec.data).collect();
-            Ok(new_recs)
-        }
-        Err(e) => Err(PyErr::from(e)),
-    }
+    read_generic::<RawacfRecord>(infile).map_err(PyErr::from)
 }
 
 /// Reads a FITACF file, returning a list of dictionaries containing the fields.
@@ -418,13 +267,7 @@ fn read_rawacf_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>>
 #[pyo3(name = "read_fitacf")]
 #[pyo3(text_signature = "(infile: str, /)")]
 fn read_fitacf_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>> {
-    match FitacfRecord::read_file(&infile) {
-        Ok(recs) => {
-            let new_recs = recs.into_iter().map(|rec| rec.data).collect();
-            Ok(new_recs)
-        }
-        Err(e) => Err(PyErr::from(e)),
-    }
+    read_generic::<FitacfRecord>(infile).map_err(PyErr::from)
 }
 
 /// Reads a GRID file, returning a list of dictionaries containing the fields.
@@ -432,13 +275,7 @@ fn read_fitacf_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>>
 #[pyo3(name = "read_grid")]
 #[pyo3(text_signature = "(infile: str, /)")]
 fn read_grid_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>> {
-    match GridRecord::read_file(&infile) {
-        Ok(recs) => {
-            let new_recs = recs.into_iter().map(|rec| rec.data).collect();
-            Ok(new_recs)
-        }
-        Err(e) => Err(PyErr::from(e)),
-    }
+    read_generic::<GridRecord>(infile).map_err(PyErr::from)
 }
 
 /// Reads a MAP file, returning a list of dictionaries containing the fields.
@@ -446,115 +283,75 @@ fn read_grid_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>> {
 #[pyo3(name = "read_map")]
 #[pyo3(text_signature = "(infile: str, /)")]
 fn read_map_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>> {
-    match MapRecord::read_file(&infile) {
-        Ok(recs) => {
-            let new_recs = recs.into_iter().map(|rec| rec.data).collect();
-            Ok(new_recs)
-        }
-        Err(e) => Err(PyErr::from(e)),
-    }
+    read_generic::<MapRecord>(infile).map_err(PyErr::from)
 }
 
-/// Reads a SND file, returning a list of dictionaries containing the fields.
+/// Reads an SND file, returning a list of dictionaries containing the fields.
 #[pyfunction]
 #[pyo3(name = "read_snd")]
 #[pyo3(text_signature = "(infile: str, /)")]
 fn read_snd_py(infile: PathBuf) -> PyResult<Vec<IndexMap<String, DmapField>>> {
-    match SndRecord::read_file(&infile) {
-        Ok(recs) => {
-            let new_recs = recs.into_iter().map(|rec| rec.data).collect();
-            Ok(new_recs)
-        }
-        Err(e) => Err(PyErr::from(e)),
-    }
+    read_generic::<SndRecord>(infile).map_err(PyErr::from)
 }
 
-/// Checks that a list of dictionaries contains DMAP records, then writes to outfile.
-///
-/// Ordinarily, this function opens the file in `append` mode. If the extension of `outfile` is
-/// `.bz2`, the bytes will be compressed using bzip2 before being written, and the file is instead
-/// opened in `create_new` mode, meaning it will fail if a file already exists at the given path.
+/// Checks that a list of dictionaries contains DMAP records, then appends to outfile.
 ///
 /// **NOTE:** No type checking is done, so the fields may not be written as the expected
-/// DMAP type, e.g. `stid` might be written as an `i8` instead of an `i16` as this function
-/// does not know that typically `stid` is an `i16`.
+/// DMAP type, e.g. `stid` might be written one byte instead of two as this function
+/// does not know that typically `stid` is two bytes.
 #[pyfunction]
 #[pyo3(name = "write_dmap")]
 #[pyo3(text_signature = "(recs: list[dict], outfile: str, /)")]
 fn write_dmap_py(recs: Vec<IndexMap<String, DmapField>>, outfile: PathBuf) -> PyResult<()> {
-    try_write_dmap(recs, &outfile).map_err(|e| PyErr::from(e))
+    try_write_dmap(recs, &outfile).map_err(PyErr::from)
 }
 
-/// Checks that a list of dictionaries contains valid IQDAT records, then writes to outfile.
-///
-/// Ordinarily, this function opens the file in `append` mode. If the extension of `outfile` is
-/// `.bz2`, the bytes will be compressed using bzip2 before being written, and the file is instead
-/// opened in `create_new` mode, meaning it will fail if a file already exists at the given path.
+/// Checks that a list of dictionaries contains valid IQDAT records, then appends to outfile.
 #[pyfunction]
 #[pyo3(name = "write_iqdat")]
 #[pyo3(text_signature = "(recs: list[dict], outfile: str, /)")]
 fn write_iqdat_py(recs: Vec<IndexMap<String, DmapField>>, outfile: PathBuf) -> PyResult<()> {
-    try_write_iqdat(recs, &outfile).map_err(|e| PyErr::from(e))
+    try_write_iqdat(recs, &outfile).map_err(PyErr::from)
 }
 
-/// Checks that a list of dictionaries contains valid RAWACF records, then writes to outfile.
-///
-/// Ordinarily, this function opens the file in `append` mode. If the extension of `outfile` is
-/// `.bz2`, the bytes will be compressed using bzip2 before being written, and the file is instead
-/// opened in `create_new` mode, meaning it will fail if a file already exists at the given path.
+/// Checks that a list of dictionaries contains valid RAWACF records, then appends to outfile.
 #[pyfunction]
 #[pyo3(name = "write_rawacf")]
 #[pyo3(text_signature = "(recs: list[dict], outfile: str, /)")]
 fn write_rawacf_py(recs: Vec<IndexMap<String, DmapField>>, outfile: PathBuf) -> PyResult<()> {
-    try_write_rawacf(recs, &outfile).map_err(|e| PyErr::from(e))
+    try_write_rawacf(recs, &outfile).map_err(PyErr::from)
 }
 
-/// Checks that a list of dictionaries contains valid FITACF records, then writes to outfile.
-///
-/// Ordinarily, this function opens the file in `append` mode. If the extension of `outfile` is
-/// `.bz2`, the bytes will be compressed using bzip2 before being written, and the file is instead
-/// opened in `create_new` mode, meaning it will fail if a file already exists at the given path.
+/// Checks that a list of dictionaries contains valid FITACF records, then appends to outfile.
 #[pyfunction]
 #[pyo3(name = "write_fitacf")]
 #[pyo3(text_signature = "(recs: list[dict], outfile: str, /)")]
 fn write_fitacf_py(recs: Vec<IndexMap<String, DmapField>>, outfile: PathBuf) -> PyResult<()> {
-    try_write_fitacf(recs, &outfile).map_err(|e| PyErr::from(e))
+    try_write_fitacf(recs, &outfile).map_err(PyErr::from)
 }
 
-/// Checks that a list of dictionaries contains valid GRID records, then writes to outfile.
-///
-/// Ordinarily, this function opens the file in `append` mode. If the extension of `outfile` is
-/// `.bz2`, the bytes will be compressed using bzip2 before being written, and the file is instead
-/// opened in `create_new` mode, meaning it will fail if a file already exists at the given path.
+/// Checks that a list of dictionaries contains valid GRID records, then appends to outfile.
 #[pyfunction]
 #[pyo3(name = "write_grid")]
 #[pyo3(text_signature = "(recs: list[dict], outfile: str, /)")]
 fn write_grid_py(recs: Vec<IndexMap<String, DmapField>>, outfile: PathBuf) -> PyResult<()> {
-    try_write_grid(recs, &outfile).map_err(|e| PyErr::from(e))
+    try_write_grid(recs, &outfile).map_err(PyErr::from)
 }
 
-/// Checks that a list of dictionaries contains valid MAP records, then writes to outfile.
-///
-/// Ordinarily, this function opens the file in `append` mode. If the extension of `outfile` is
-/// `.bz2`, the bytes will be compressed using bzip2 before being written, and the file is instead
-/// opened in `create_new` mode, meaning it will fail if a file already exists at the given path.
+/// Checks that a list of dictionaries contains valid MAP records, then appends to outfile.
 #[pyfunction]
 #[pyo3(name = "write_map")]
 #[pyo3(text_signature = "(recs: list[dict], outfile: str, /)")]
 fn write_map_py(recs: Vec<IndexMap<String, DmapField>>, outfile: PathBuf) -> PyResult<()> {
-    try_write_map(recs, &outfile).map_err(|e| PyErr::from(e))
+    try_write_map(recs, &outfile).map_err(PyErr::from)
 }
 
-/// Checks that a list of dictionaries contains valid SND records, then writes to outfile.
-///
-/// Ordinarily, this function opens the file in `append` mode. If the extension of `outfile` is
-/// `.bz2`, the bytes will be compressed using bzip2 before being written, and the file is instead
-/// opened in `create_new` mode, meaning it will fail if a file already exists at the given path.
+/// Checks that a list of dictionaries contains valid SND records, then appends to outfile.
 #[pyfunction]
 #[pyo3(name = "write_snd")]
 #[pyo3(text_signature = "(recs: list[dict], outfile: str, /)")]
 fn write_snd_py(recs: Vec<IndexMap<String, DmapField>>, outfile: PathBuf) -> PyResult<()> {
-    try_write_snd(recs, &outfile).map_err(|e| PyErr::from(e))
+    try_write_snd(recs, &outfile).map_err(PyErr::from)
 }
 
 /// Functions for SuperDARN DMAP file format I/O.

--- a/src/types.rs
+++ b/src/types.rs
@@ -464,80 +464,130 @@ impl TryFrom<DmapVec> for ArrayD<i8> {
     type Error = DmapError;
 
     fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
-        if let DmapVec::Char(x) = value { Ok(x) }
-        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<i8>".to_string())) }
+        if let DmapVec::Char(x) = value {
+            Ok(x)
+        } else {
+            Err(DmapError::InvalidVector(
+                "Cannot convert to ArrayD<i8>".to_string(),
+            ))
+        }
     }
 }
 impl TryFrom<DmapVec> for ArrayD<i16> {
     type Error = DmapError;
 
     fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
-        if let DmapVec::Short(x) = value { Ok(x) }
-        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<i16>".to_string())) }
+        if let DmapVec::Short(x) = value {
+            Ok(x)
+        } else {
+            Err(DmapError::InvalidVector(
+                "Cannot convert to ArrayD<i16>".to_string(),
+            ))
+        }
     }
 }
 impl TryFrom<DmapVec> for ArrayD<i32> {
     type Error = DmapError;
 
     fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
-        if let DmapVec::Int(x) = value { Ok(x) }
-        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<i32>".to_string())) }
+        if let DmapVec::Int(x) = value {
+            Ok(x)
+        } else {
+            Err(DmapError::InvalidVector(
+                "Cannot convert to ArrayD<i32>".to_string(),
+            ))
+        }
     }
 }
 impl TryFrom<DmapVec> for ArrayD<i64> {
     type Error = DmapError;
 
     fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
-        if let DmapVec::Long(x) = value { Ok(x) }
-        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<i64>".to_string())) }
+        if let DmapVec::Long(x) = value {
+            Ok(x)
+        } else {
+            Err(DmapError::InvalidVector(
+                "Cannot convert to ArrayD<i64>".to_string(),
+            ))
+        }
     }
 }
 impl TryFrom<DmapVec> for ArrayD<u8> {
     type Error = DmapError;
 
     fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
-        if let DmapVec::Uchar(x) = value { Ok(x) }
-        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<u8>".to_string())) }
+        if let DmapVec::Uchar(x) = value {
+            Ok(x)
+        } else {
+            Err(DmapError::InvalidVector(
+                "Cannot convert to ArrayD<u8>".to_string(),
+            ))
+        }
     }
 }
 impl TryFrom<DmapVec> for ArrayD<u16> {
     type Error = DmapError;
 
     fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
-        if let DmapVec::Ushort(x) = value { Ok(x) }
-        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<u16>".to_string())) }
+        if let DmapVec::Ushort(x) = value {
+            Ok(x)
+        } else {
+            Err(DmapError::InvalidVector(
+                "Cannot convert to ArrayD<u16>".to_string(),
+            ))
+        }
     }
 }
 impl TryFrom<DmapVec> for ArrayD<u32> {
     type Error = DmapError;
 
     fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
-        if let DmapVec::Uint(x) = value { Ok(x) }
-        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<u32>".to_string())) }
+        if let DmapVec::Uint(x) = value {
+            Ok(x)
+        } else {
+            Err(DmapError::InvalidVector(
+                "Cannot convert to ArrayD<u32>".to_string(),
+            ))
+        }
     }
 }
 impl TryFrom<DmapVec> for ArrayD<u64> {
     type Error = DmapError;
 
     fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
-        if let DmapVec::Ulong(x) = value { Ok(x) }
-        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<u64>".to_string())) }
+        if let DmapVec::Ulong(x) = value {
+            Ok(x)
+        } else {
+            Err(DmapError::InvalidVector(
+                "Cannot convert to ArrayD<u64>".to_string(),
+            ))
+        }
     }
 }
 impl TryFrom<DmapVec> for ArrayD<f32> {
     type Error = DmapError;
 
     fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
-        if let DmapVec::Float(x) = value { Ok(x) }
-        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<f32>".to_string())) }
+        if let DmapVec::Float(x) = value {
+            Ok(x)
+        } else {
+            Err(DmapError::InvalidVector(
+                "Cannot convert to ArrayD<f32>".to_string(),
+            ))
+        }
     }
 }
 impl TryFrom<DmapVec> for ArrayD<f64> {
     type Error = DmapError;
 
     fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
-        if let DmapVec::Double(x) = value { Ok(x) }
-        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<f64>".to_string())) }
+        if let DmapVec::Double(x) = value {
+            Ok(x)
+        } else {
+            Err(DmapError::InvalidVector(
+                "Cannot convert to ArrayD<f64>".to_string(),
+            ))
+        }
     }
 }
 
@@ -679,7 +729,9 @@ impl TryFrom<DmapField> for i8 {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Scalar(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidScalar("Cannot interpret as i8".to_string()))
+            _ => Err(Self::Error::InvalidScalar(
+                "Cannot interpret as i8".to_string(),
+            )),
         }
     }
 }
@@ -689,7 +741,9 @@ impl TryFrom<DmapField> for i16 {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Scalar(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidScalar("Cannot interpret as i16".to_string()))
+            _ => Err(Self::Error::InvalidScalar(
+                "Cannot interpret as i16".to_string(),
+            )),
         }
     }
 }
@@ -699,7 +753,9 @@ impl TryFrom<DmapField> for i32 {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Scalar(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidScalar("Cannot interpret as i32".to_string()))
+            _ => Err(Self::Error::InvalidScalar(
+                "Cannot interpret as i32".to_string(),
+            )),
         }
     }
 }
@@ -709,7 +765,9 @@ impl TryFrom<DmapField> for i64 {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Scalar(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidScalar("Cannot interpret as i64".to_string()))
+            _ => Err(Self::Error::InvalidScalar(
+                "Cannot interpret as i64".to_string(),
+            )),
         }
     }
 }
@@ -719,7 +777,9 @@ impl TryFrom<DmapField> for u8 {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Scalar(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidScalar("Cannot interpret as u8".to_string()))
+            _ => Err(Self::Error::InvalidScalar(
+                "Cannot interpret as u8".to_string(),
+            )),
         }
     }
 }
@@ -729,7 +789,9 @@ impl TryFrom<DmapField> for u16 {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Scalar(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidScalar("Cannot interpret as u16".to_string()))
+            _ => Err(Self::Error::InvalidScalar(
+                "Cannot interpret as u16".to_string(),
+            )),
         }
     }
 }
@@ -739,7 +801,9 @@ impl TryFrom<DmapField> for u32 {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Scalar(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidScalar("Cannot interpret as u32".to_string()))
+            _ => Err(Self::Error::InvalidScalar(
+                "Cannot interpret as u32".to_string(),
+            )),
         }
     }
 }
@@ -749,7 +813,9 @@ impl TryFrom<DmapField> for u64 {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Scalar(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidScalar("Cannot interpret as u64".to_string()))
+            _ => Err(Self::Error::InvalidScalar(
+                "Cannot interpret as u64".to_string(),
+            )),
         }
     }
 }
@@ -759,7 +825,9 @@ impl TryFrom<DmapField> for f32 {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Scalar(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidScalar("Cannot interpret as f32".to_string()))
+            _ => Err(Self::Error::InvalidScalar(
+                "Cannot interpret as f32".to_string(),
+            )),
         }
     }
 }
@@ -769,7 +837,9 @@ impl TryFrom<DmapField> for f64 {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Scalar(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidScalar("Cannot interpret as f64".to_string()))
+            _ => Err(Self::Error::InvalidScalar(
+                "Cannot interpret as f64".to_string(),
+            )),
         }
     }
 }
@@ -779,7 +849,9 @@ impl TryFrom<DmapField> for String {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Scalar(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidScalar("Cannot interpret vector as String".to_string()))
+            _ => Err(Self::Error::InvalidScalar(
+                "Cannot interpret vector as String".to_string(),
+            )),
         }
     }
 }
@@ -789,7 +861,9 @@ impl TryFrom<DmapField> for ArrayD<i8> {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Vector(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<i8>".to_string()))
+            _ => Err(Self::Error::InvalidVector(
+                "Cannot interpret as ArrayD<i8>".to_string(),
+            )),
         }
     }
 }
@@ -799,7 +873,9 @@ impl TryFrom<DmapField> for ArrayD<i16> {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Vector(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<i16>".to_string()))
+            _ => Err(Self::Error::InvalidVector(
+                "Cannot interpret as ArrayD<i16>".to_string(),
+            )),
         }
     }
 }
@@ -809,7 +885,9 @@ impl TryFrom<DmapField> for ArrayD<i32> {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Vector(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<i32>".to_string()))
+            _ => Err(Self::Error::InvalidVector(
+                "Cannot interpret as ArrayD<i32>".to_string(),
+            )),
         }
     }
 }
@@ -819,7 +897,9 @@ impl TryFrom<DmapField> for ArrayD<i64> {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Vector(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<i64>".to_string()))
+            _ => Err(Self::Error::InvalidVector(
+                "Cannot interpret as ArrayD<i64>".to_string(),
+            )),
         }
     }
 }
@@ -829,7 +909,9 @@ impl TryFrom<DmapField> for ArrayD<u8> {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Vector(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<u8>".to_string()))
+            _ => Err(Self::Error::InvalidVector(
+                "Cannot interpret as ArrayD<u8>".to_string(),
+            )),
         }
     }
 }
@@ -839,7 +921,9 @@ impl TryFrom<DmapField> for ArrayD<u16> {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Vector(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<u16>".to_string()))
+            _ => Err(Self::Error::InvalidVector(
+                "Cannot interpret as ArrayD<u16>".to_string(),
+            )),
         }
     }
 }
@@ -849,7 +933,9 @@ impl TryFrom<DmapField> for ArrayD<u32> {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Vector(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<u32>".to_string()))
+            _ => Err(Self::Error::InvalidVector(
+                "Cannot interpret as ArrayD<u32>".to_string(),
+            )),
         }
     }
 }
@@ -859,7 +945,9 @@ impl TryFrom<DmapField> for ArrayD<u64> {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Vector(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<u64>".to_string()))
+            _ => Err(Self::Error::InvalidVector(
+                "Cannot interpret as ArrayD<u64>".to_string(),
+            )),
         }
     }
 }
@@ -869,7 +957,9 @@ impl TryFrom<DmapField> for ArrayD<f32> {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Vector(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<f32>".to_string()))
+            _ => Err(Self::Error::InvalidVector(
+                "Cannot interpret as ArrayD<f32>".to_string(),
+            )),
         }
     }
 }
@@ -879,7 +969,9 @@ impl TryFrom<DmapField> for ArrayD<f64> {
     fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
         match value {
             DmapField::Vector(x) => x.try_into(),
-            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<f64>".to_string()))
+            _ => Err(Self::Error::InvalidVector(
+                "Cannot interpret as ArrayD<f64>".to_string(),
+            )),
         }
     }
 }
@@ -1096,7 +1188,7 @@ impl DmapType for String {
     }
     fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let data = String::from_utf8(bytes.to_owned())
-            .map_err(|_| DmapError::InvalidScalar(format!("Cannot convert bytes to String")))?;
+            .map_err(|_| DmapError::InvalidScalar("Cannot convert bytes to String".to_string()))?;
         Ok(data.trim_end_matches(char::from(0)).to_string())
     }
     fn dmap_type(&self) -> Type {
@@ -1322,8 +1414,8 @@ pub fn check_scalar(
     expected_type: Type,
 ) -> Result<()> {
     match fields.get(name) {
-        Some(&DmapField::Scalar(ref data)) if data.get_type() == expected_type => Ok(()),
-        Some(&DmapField::Scalar(ref data)) => Err(DmapError::InvalidScalar(format!(
+        Some(DmapField::Scalar(data)) if data.get_type() == expected_type => Ok(()),
+        Some(DmapField::Scalar(data)) => Err(DmapError::InvalidScalar(format!(
             "{name} is of type {}, expected {}",
             data.get_type(),
             expected_type
@@ -1342,8 +1434,8 @@ pub fn check_scalar_opt(
     expected_type: Type,
 ) -> Result<()> {
     match fields.get(name) {
-        Some(&DmapField::Scalar(ref data)) if data.get_type() == expected_type => Ok(()),
-        Some(&DmapField::Scalar(ref data)) => Err(DmapError::InvalidScalar(format!(
+        Some(DmapField::Scalar(data)) if data.get_type() == expected_type => Ok(()),
+        Some(DmapField::Scalar(data)) => Err(DmapError::InvalidScalar(format!(
             "{name} is of type {}, expected {}",
             data.get_type(),
             expected_type

--- a/src/types.rs
+++ b/src/types.rs
@@ -117,6 +117,7 @@ impl Type {
         }
     }
 }
+
 /// A scalar field in a DMAP record.
 #[derive(Debug, Clone, PartialEq, FromPyObject)]
 #[repr(C)]
@@ -153,16 +154,16 @@ impl DmapScalar {
     /// Converts `self` into a new `Type`, if possible.
     pub(crate) fn cast_as(&self, new_type: &Type) -> Result<Self> {
         match new_type {
-            Type::Char => Ok(Self::Char(i8::try_from(self)?)),
-            Type::Short => Ok(Self::Short(i16::try_from(self)?)),
-            Type::Int => Ok(Self::Int(i32::try_from(self)?)),
-            Type::Long => Ok(Self::Long(i64::try_from(self)?)),
-            Type::Uchar => Ok(Self::Uchar(u8::try_from(self)?)),
-            Type::Ushort => Ok(Self::Ushort(u16::try_from(self)?)),
-            Type::Uint => Ok(Self::Uint(u32::try_from(self)?)),
-            Type::Ulong => Ok(Self::Ulong(u64::try_from(self)?)),
-            Type::Float => Ok(Self::Float(f32::try_from(self)?)),
-            Type::Double => Ok(Self::Double(f64::try_from(self)?)),
+            Type::Char => Ok(Self::Char(i8::try_from(self.clone())?)),
+            Type::Short => Ok(Self::Short(i16::try_from(self.clone())?)),
+            Type::Int => Ok(Self::Int(i32::try_from(self.clone())?)),
+            Type::Long => Ok(Self::Long(i64::try_from(self.clone())?)),
+            Type::Uchar => Ok(Self::Uchar(u8::try_from(self.clone())?)),
+            Type::Ushort => Ok(Self::Ushort(u16::try_from(self.clone())?)),
+            Type::Uint => Ok(Self::Uint(u32::try_from(self.clone())?)),
+            Type::Ulong => Ok(Self::Ulong(u64::try_from(self.clone())?)),
+            Type::Float => Ok(Self::Float(f32::try_from(self.clone())?)),
+            Type::Double => Ok(Self::Double(f64::try_from(self.clone())?)),
             Type::String => Err(DmapError::InvalidScalar(
                 "Unable to cast value to String".to_string(),
             )),
@@ -351,7 +352,7 @@ impl DmapVec {
         bytes
     }
     /// Gets the dimensions of the vector.
-    pub(crate) fn shape(&self) -> &[usize] {
+    pub fn shape(&self) -> &[usize] {
         match self {
             DmapVec::Char(x) => x.shape(),
             DmapVec::Short(x) => x.shape(),
@@ -409,6 +410,136 @@ impl<'py> FromPyObject<'py> for DmapVec {
         }
     }
 }
+impl From<ArrayD<i8>> for DmapVec {
+    fn from(value: ArrayD<i8>) -> Self {
+        DmapVec::Char(value)
+    }
+}
+impl From<ArrayD<i16>> for DmapVec {
+    fn from(value: ArrayD<i16>) -> Self {
+        DmapVec::Short(value)
+    }
+}
+impl From<ArrayD<i32>> for DmapVec {
+    fn from(value: ArrayD<i32>) -> Self {
+        DmapVec::Int(value)
+    }
+}
+impl From<ArrayD<i64>> for DmapVec {
+    fn from(value: ArrayD<i64>) -> Self {
+        DmapVec::Long(value)
+    }
+}
+impl From<ArrayD<u8>> for DmapVec {
+    fn from(value: ArrayD<u8>) -> Self {
+        DmapVec::Uchar(value)
+    }
+}
+impl From<ArrayD<u16>> for DmapVec {
+    fn from(value: ArrayD<u16>) -> Self {
+        DmapVec::Ushort(value)
+    }
+}
+impl From<ArrayD<u32>> for DmapVec {
+    fn from(value: ArrayD<u32>) -> Self {
+        DmapVec::Uint(value)
+    }
+}
+impl From<ArrayD<u64>> for DmapVec {
+    fn from(value: ArrayD<u64>) -> Self {
+        DmapVec::Ulong(value)
+    }
+}
+impl From<ArrayD<f32>> for DmapVec {
+    fn from(value: ArrayD<f32>) -> Self {
+        DmapVec::Float(value)
+    }
+}
+impl From<ArrayD<f64>> for DmapVec {
+    fn from(value: ArrayD<f64>) -> Self {
+        DmapVec::Double(value)
+    }
+}
+impl TryFrom<DmapVec> for ArrayD<i8> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
+        if let DmapVec::Char(x) = value { Ok(x) }
+        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<i8>".to_string())) }
+    }
+}
+impl TryFrom<DmapVec> for ArrayD<i16> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
+        if let DmapVec::Short(x) = value { Ok(x) }
+        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<i16>".to_string())) }
+    }
+}
+impl TryFrom<DmapVec> for ArrayD<i32> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
+        if let DmapVec::Int(x) = value { Ok(x) }
+        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<i32>".to_string())) }
+    }
+}
+impl TryFrom<DmapVec> for ArrayD<i64> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
+        if let DmapVec::Long(x) = value { Ok(x) }
+        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<i64>".to_string())) }
+    }
+}
+impl TryFrom<DmapVec> for ArrayD<u8> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
+        if let DmapVec::Uchar(x) = value { Ok(x) }
+        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<u8>".to_string())) }
+    }
+}
+impl TryFrom<DmapVec> for ArrayD<u16> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
+        if let DmapVec::Ushort(x) = value { Ok(x) }
+        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<u16>".to_string())) }
+    }
+}
+impl TryFrom<DmapVec> for ArrayD<u32> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
+        if let DmapVec::Uint(x) = value { Ok(x) }
+        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<u32>".to_string())) }
+    }
+}
+impl TryFrom<DmapVec> for ArrayD<u64> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
+        if let DmapVec::Ulong(x) = value { Ok(x) }
+        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<u64>".to_string())) }
+    }
+}
+impl TryFrom<DmapVec> for ArrayD<f32> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
+        if let DmapVec::Float(x) = value { Ok(x) }
+        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<f32>".to_string())) }
+    }
+}
+impl TryFrom<DmapVec> for ArrayD<f64> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapVec) -> std::result::Result<Self, Self::Error> {
+        if let DmapVec::Double(x) = value { Ok(x) }
+        else { Err(DmapError::InvalidVector("Cannot convert to ArrayD<f64>".to_string())) }
+    }
+}
 
 /// A generic field of a DMAP record.
 ///
@@ -434,6 +565,321 @@ impl IntoPy<PyObject> for DmapField {
         match self {
             DmapField::Scalar(x) => x.into_py(py),
             DmapField::Vector(x) => x.into_py(py),
+        }
+    }
+}
+impl From<i8> for DmapField {
+    fn from(value: i8) -> Self {
+        DmapField::Scalar(DmapScalar::Char(value))
+    }
+}
+impl From<i16> for DmapField {
+    fn from(value: i16) -> Self {
+        DmapField::Scalar(DmapScalar::Short(value))
+    }
+}
+impl From<i32> for DmapField {
+    fn from(value: i32) -> Self {
+        DmapField::Scalar(DmapScalar::Int(value))
+    }
+}
+impl From<i64> for DmapField {
+    fn from(value: i64) -> Self {
+        DmapField::Scalar(DmapScalar::Long(value))
+    }
+}
+impl From<u8> for DmapField {
+    fn from(value: u8) -> Self {
+        DmapField::Scalar(DmapScalar::Uchar(value))
+    }
+}
+impl From<u16> for DmapField {
+    fn from(value: u16) -> Self {
+        DmapField::Scalar(DmapScalar::Ushort(value))
+    }
+}
+impl From<u32> for DmapField {
+    fn from(value: u32) -> Self {
+        DmapField::Scalar(DmapScalar::Uint(value))
+    }
+}
+impl From<u64> for DmapField {
+    fn from(value: u64) -> Self {
+        DmapField::Scalar(DmapScalar::Ulong(value))
+    }
+}
+impl From<f32> for DmapField {
+    fn from(value: f32) -> Self {
+        DmapField::Scalar(DmapScalar::Float(value))
+    }
+}
+impl From<f64> for DmapField {
+    fn from(value: f64) -> Self {
+        DmapField::Scalar(DmapScalar::Double(value))
+    }
+}
+impl From<String> for DmapField {
+    fn from(value: String) -> Self {
+        DmapField::Scalar(DmapScalar::String(value))
+    }
+}
+impl From<ArrayD<i8>> for DmapField {
+    fn from(value: ArrayD<i8>) -> Self {
+        DmapField::Vector(DmapVec::Char(value))
+    }
+}
+impl From<ArrayD<i16>> for DmapField {
+    fn from(value: ArrayD<i16>) -> Self {
+        DmapField::Vector(DmapVec::Short(value))
+    }
+}
+impl From<ArrayD<i32>> for DmapField {
+    fn from(value: ArrayD<i32>) -> Self {
+        DmapField::Vector(DmapVec::Int(value))
+    }
+}
+impl From<ArrayD<i64>> for DmapField {
+    fn from(value: ArrayD<i64>) -> Self {
+        DmapField::Vector(DmapVec::Long(value))
+    }
+}
+impl From<ArrayD<u8>> for DmapField {
+    fn from(value: ArrayD<u8>) -> Self {
+        DmapField::Vector(DmapVec::Uchar(value))
+    }
+}
+impl From<ArrayD<u16>> for DmapField {
+    fn from(value: ArrayD<u16>) -> Self {
+        DmapField::Vector(DmapVec::Ushort(value))
+    }
+}
+impl From<ArrayD<u32>> for DmapField {
+    fn from(value: ArrayD<u32>) -> Self {
+        DmapField::Vector(DmapVec::Uint(value))
+    }
+}
+impl From<ArrayD<u64>> for DmapField {
+    fn from(value: ArrayD<u64>) -> Self {
+        DmapField::Vector(DmapVec::Ulong(value))
+    }
+}
+impl From<ArrayD<f32>> for DmapField {
+    fn from(value: ArrayD<f32>) -> Self {
+        DmapField::Vector(DmapVec::Float(value))
+    }
+}
+impl From<ArrayD<f64>> for DmapField {
+    fn from(value: ArrayD<f64>) -> Self {
+        DmapField::Vector(DmapVec::Double(value))
+    }
+}
+impl TryFrom<DmapField> for i8 {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Scalar(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidScalar("Cannot interpret as i8".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for i16 {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Scalar(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidScalar("Cannot interpret as i16".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for i32 {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Scalar(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidScalar("Cannot interpret as i32".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for i64 {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Scalar(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidScalar("Cannot interpret as i64".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for u8 {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Scalar(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidScalar("Cannot interpret as u8".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for u16 {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Scalar(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidScalar("Cannot interpret as u16".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for u32 {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Scalar(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidScalar("Cannot interpret as u32".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for u64 {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Scalar(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidScalar("Cannot interpret as u64".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for f32 {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Scalar(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidScalar("Cannot interpret as f32".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for f64 {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Scalar(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidScalar("Cannot interpret as f64".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for String {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Scalar(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidScalar("Cannot interpret vector as String".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for ArrayD<i8> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Vector(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<i8>".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for ArrayD<i16> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Vector(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<i16>".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for ArrayD<i32> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Vector(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<i32>".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for ArrayD<i64> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Vector(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<i64>".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for ArrayD<u8> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Vector(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<u8>".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for ArrayD<u16> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Vector(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<u16>".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for ArrayD<u32> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Vector(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<u32>".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for ArrayD<u64> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Vector(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<u64>".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for ArrayD<f32> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Vector(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<f32>".to_string()))
+        }
+    }
+}
+impl TryFrom<DmapField> for ArrayD<f64> {
+    type Error = DmapError;
+
+    fn try_from(value: DmapField) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapField::Vector(x) => x.try_into(),
+            _ => Err(Self::Error::InvalidVector("Cannot interpret as ArrayD<f64>".to_string()))
         }
     }
 }
@@ -657,202 +1103,213 @@ impl DmapType for String {
         Type::String
     }
 }
-impl TryFrom<&DmapScalar> for u8 {
+impl TryFrom<DmapScalar> for u8 {
     type Error = DmapError;
-    fn try_from(value: &DmapScalar) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: DmapScalar) -> std::result::Result<Self, Self::Error> {
         match value {
-            DmapScalar::Char(x) => Ok(x.clone() as u8),
-            DmapScalar::Short(x) => Ok(x.clone() as u8),
-            DmapScalar::Int(x) => Ok(x.clone() as u8),
-            DmapScalar::Long(x) => Ok(x.clone() as u8),
-            DmapScalar::Uchar(x) => Ok(x.clone()),
-            DmapScalar::Ushort(x) => Ok(x.clone() as u8),
-            DmapScalar::Uint(x) => Ok(x.clone() as u8),
-            DmapScalar::Ulong(x) => Ok(x.clone() as u8),
-            DmapScalar::Float(x) => Ok(x.clone() as u8),
-            DmapScalar::Double(x) => Ok(x.clone() as u8),
+            DmapScalar::Char(x) => Ok(x as u8),
+            DmapScalar::Short(x) => Ok(x as u8),
+            DmapScalar::Int(x) => Ok(x as u8),
+            DmapScalar::Long(x) => Ok(x as u8),
+            DmapScalar::Uchar(x) => Ok(x),
+            DmapScalar::Ushort(x) => Ok(x as u8),
+            DmapScalar::Uint(x) => Ok(x as u8),
+            DmapScalar::Ulong(x) => Ok(x as u8),
+            DmapScalar::Float(x) => Ok(x as u8),
+            DmapScalar::Double(x) => Ok(x as u8),
             DmapScalar::String(x) => Err(DmapError::InvalidScalar(format!(
                 "Unable to convert {x} to u8"
             ))),
         }
     }
 }
-impl TryFrom<&DmapScalar> for u16 {
+impl TryFrom<DmapScalar> for u16 {
     type Error = DmapError;
-    fn try_from(value: &DmapScalar) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: DmapScalar) -> std::result::Result<Self, Self::Error> {
         match value {
-            DmapScalar::Char(x) => Ok(x.clone() as u16),
-            DmapScalar::Short(x) => Ok(x.clone() as u16),
-            DmapScalar::Int(x) => Ok(x.clone() as u16),
-            DmapScalar::Long(x) => Ok(x.clone() as u16),
-            DmapScalar::Uchar(x) => Ok(x.clone() as u16),
-            DmapScalar::Ushort(x) => Ok(x.clone()),
-            DmapScalar::Uint(x) => Ok(x.clone() as u16),
-            DmapScalar::Ulong(x) => Ok(x.clone() as u16),
-            DmapScalar::Float(x) => Ok(x.clone() as u16),
-            DmapScalar::Double(x) => Ok(x.clone() as u16),
+            DmapScalar::Char(x) => Ok(x as u16),
+            DmapScalar::Short(x) => Ok(x as u16),
+            DmapScalar::Int(x) => Ok(x as u16),
+            DmapScalar::Long(x) => Ok(x as u16),
+            DmapScalar::Uchar(x) => Ok(x as u16),
+            DmapScalar::Ushort(x) => Ok(x),
+            DmapScalar::Uint(x) => Ok(x as u16),
+            DmapScalar::Ulong(x) => Ok(x as u16),
+            DmapScalar::Float(x) => Ok(x as u16),
+            DmapScalar::Double(x) => Ok(x as u16),
             DmapScalar::String(x) => Err(DmapError::InvalidScalar(format!(
                 "Unable to convert {x} to u16"
             ))),
         }
     }
 }
-impl TryFrom<&DmapScalar> for u32 {
+impl TryFrom<DmapScalar> for u32 {
     type Error = DmapError;
-    fn try_from(value: &DmapScalar) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: DmapScalar) -> std::result::Result<Self, Self::Error> {
         match value {
-            DmapScalar::Char(x) => Ok(x.clone() as u32),
-            DmapScalar::Short(x) => Ok(x.clone() as u32),
-            DmapScalar::Int(x) => Ok(x.clone() as u32),
-            DmapScalar::Long(x) => Ok(x.clone() as u32),
-            DmapScalar::Uchar(x) => Ok(x.clone() as u32),
-            DmapScalar::Ushort(x) => Ok(x.clone() as u32),
-            DmapScalar::Uint(x) => Ok(x.clone()),
-            DmapScalar::Ulong(x) => Ok(x.clone() as u32),
-            DmapScalar::Float(x) => Ok(x.clone() as u32),
-            DmapScalar::Double(x) => Ok(x.clone() as u32),
+            DmapScalar::Char(x) => Ok(x as u32),
+            DmapScalar::Short(x) => Ok(x as u32),
+            DmapScalar::Int(x) => Ok(x as u32),
+            DmapScalar::Long(x) => Ok(x as u32),
+            DmapScalar::Uchar(x) => Ok(x as u32),
+            DmapScalar::Ushort(x) => Ok(x as u32),
+            DmapScalar::Uint(x) => Ok(x),
+            DmapScalar::Ulong(x) => Ok(x as u32),
+            DmapScalar::Float(x) => Ok(x as u32),
+            DmapScalar::Double(x) => Ok(x as u32),
             DmapScalar::String(x) => Err(DmapError::InvalidScalar(format!(
                 "Unable to convert {x} to u32"
             ))),
         }
     }
 }
-impl TryFrom<&DmapScalar> for u64 {
+impl TryFrom<DmapScalar> for u64 {
     type Error = DmapError;
-    fn try_from(value: &DmapScalar) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: DmapScalar) -> std::result::Result<Self, Self::Error> {
         match value {
-            DmapScalar::Char(x) => Ok(x.clone() as u64),
-            DmapScalar::Short(x) => Ok(x.clone() as u64),
-            DmapScalar::Int(x) => Ok(x.clone() as u64),
-            DmapScalar::Long(x) => Ok(x.clone() as u64),
-            DmapScalar::Uchar(x) => Ok(x.clone() as u64),
-            DmapScalar::Ushort(x) => Ok(x.clone() as u64),
-            DmapScalar::Uint(x) => Ok(x.clone() as u64),
-            DmapScalar::Ulong(x) => Ok(x.clone()),
-            DmapScalar::Float(x) => Ok(x.clone() as u64),
-            DmapScalar::Double(x) => Ok(x.clone() as u64),
+            DmapScalar::Char(x) => Ok(x as u64),
+            DmapScalar::Short(x) => Ok(x as u64),
+            DmapScalar::Int(x) => Ok(x as u64),
+            DmapScalar::Long(x) => Ok(x as u64),
+            DmapScalar::Uchar(x) => Ok(x as u64),
+            DmapScalar::Ushort(x) => Ok(x as u64),
+            DmapScalar::Uint(x) => Ok(x as u64),
+            DmapScalar::Ulong(x) => Ok(x),
+            DmapScalar::Float(x) => Ok(x as u64),
+            DmapScalar::Double(x) => Ok(x as u64),
             DmapScalar::String(x) => Err(DmapError::InvalidScalar(format!(
                 "Unable to convert {x} to u64"
             ))),
         }
     }
 }
-impl TryFrom<&DmapScalar> for i8 {
+impl TryFrom<DmapScalar> for i8 {
     type Error = DmapError;
-    fn try_from(value: &DmapScalar) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: DmapScalar) -> std::result::Result<Self, Self::Error> {
         match value {
-            DmapScalar::Char(x) => Ok(x.clone()),
-            DmapScalar::Short(x) => Ok(x.clone() as i8),
-            DmapScalar::Int(x) => Ok(x.clone() as i8),
-            DmapScalar::Long(x) => Ok(x.clone() as i8),
-            DmapScalar::Uchar(x) => Ok(x.clone() as i8),
-            DmapScalar::Ushort(x) => Ok(x.clone() as i8),
-            DmapScalar::Uint(x) => Ok(x.clone() as i8),
-            DmapScalar::Ulong(x) => Ok(x.clone() as i8),
-            DmapScalar::Float(x) => Ok(x.clone() as i8),
-            DmapScalar::Double(x) => Ok(x.clone() as i8),
+            DmapScalar::Char(x) => Ok(x),
+            DmapScalar::Short(x) => Ok(x as i8),
+            DmapScalar::Int(x) => Ok(x as i8),
+            DmapScalar::Long(x) => Ok(x as i8),
+            DmapScalar::Uchar(x) => Ok(x as i8),
+            DmapScalar::Ushort(x) => Ok(x as i8),
+            DmapScalar::Uint(x) => Ok(x as i8),
+            DmapScalar::Ulong(x) => Ok(x as i8),
+            DmapScalar::Float(x) => Ok(x as i8),
+            DmapScalar::Double(x) => Ok(x as i8),
             DmapScalar::String(x) => Err(DmapError::InvalidScalar(format!(
                 "Unable to convert {x} to i8"
             ))),
         }
     }
 }
-impl TryFrom<&DmapScalar> for i16 {
+impl TryFrom<DmapScalar> for i16 {
     type Error = DmapError;
-    fn try_from(value: &DmapScalar) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: DmapScalar) -> std::result::Result<Self, Self::Error> {
         match value {
-            DmapScalar::Char(x) => Ok(x.clone() as i16),
-            DmapScalar::Short(x) => Ok(x.clone()),
-            DmapScalar::Int(x) => Ok(x.clone() as i16),
-            DmapScalar::Long(x) => Ok(x.clone() as i16),
-            DmapScalar::Uchar(x) => Ok(x.clone() as i16),
-            DmapScalar::Ushort(x) => Ok(x.clone() as i16),
-            DmapScalar::Uint(x) => Ok(x.clone() as i16),
-            DmapScalar::Ulong(x) => Ok(x.clone() as i16),
-            DmapScalar::Float(x) => Ok(x.clone() as i16),
-            DmapScalar::Double(x) => Ok(x.clone() as i16),
+            DmapScalar::Char(x) => Ok(x as i16),
+            DmapScalar::Short(x) => Ok(x),
+            DmapScalar::Int(x) => Ok(x as i16),
+            DmapScalar::Long(x) => Ok(x as i16),
+            DmapScalar::Uchar(x) => Ok(x as i16),
+            DmapScalar::Ushort(x) => Ok(x as i16),
+            DmapScalar::Uint(x) => Ok(x as i16),
+            DmapScalar::Ulong(x) => Ok(x as i16),
+            DmapScalar::Float(x) => Ok(x as i16),
+            DmapScalar::Double(x) => Ok(x as i16),
             DmapScalar::String(x) => Err(DmapError::InvalidScalar(format!(
                 "Unable to convert {x} to i16"
             ))),
         }
     }
 }
-impl TryFrom<&DmapScalar> for i32 {
+impl TryFrom<DmapScalar> for i32 {
     type Error = DmapError;
-    fn try_from(value: &DmapScalar) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: DmapScalar) -> std::result::Result<Self, Self::Error> {
         match value {
-            DmapScalar::Char(x) => Ok(x.clone() as i32),
-            DmapScalar::Short(x) => Ok(x.clone() as i32),
-            DmapScalar::Int(x) => Ok(x.clone()),
-            DmapScalar::Long(x) => Ok(x.clone() as i32),
-            DmapScalar::Uchar(x) => Ok(x.clone() as i32),
-            DmapScalar::Ushort(x) => Ok(x.clone() as i32),
-            DmapScalar::Uint(x) => Ok(x.clone() as i32),
-            DmapScalar::Ulong(x) => Ok(x.clone() as i32),
-            DmapScalar::Float(x) => Ok(x.clone() as i32),
-            DmapScalar::Double(x) => Ok(x.clone() as i32),
+            DmapScalar::Char(x) => Ok(x as i32),
+            DmapScalar::Short(x) => Ok(x as i32),
+            DmapScalar::Int(x) => Ok(x),
+            DmapScalar::Long(x) => Ok(x as i32),
+            DmapScalar::Uchar(x) => Ok(x as i32),
+            DmapScalar::Ushort(x) => Ok(x as i32),
+            DmapScalar::Uint(x) => Ok(x as i32),
+            DmapScalar::Ulong(x) => Ok(x as i32),
+            DmapScalar::Float(x) => Ok(x as i32),
+            DmapScalar::Double(x) => Ok(x as i32),
             DmapScalar::String(x) => Err(DmapError::InvalidScalar(format!(
                 "Unable to convert {x} to i32"
             ))),
         }
     }
 }
-impl TryFrom<&DmapScalar> for i64 {
+impl TryFrom<DmapScalar> for i64 {
     type Error = DmapError;
-    fn try_from(value: &DmapScalar) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: DmapScalar) -> std::result::Result<Self, Self::Error> {
         match value {
-            DmapScalar::Char(x) => Ok(x.clone() as i64),
-            DmapScalar::Short(x) => Ok(x.clone() as i64),
-            DmapScalar::Int(x) => Ok(x.clone() as i64),
-            DmapScalar::Long(x) => Ok(x.clone()),
-            DmapScalar::Uchar(x) => Ok(x.clone() as i64),
-            DmapScalar::Ushort(x) => Ok(x.clone() as i64),
-            DmapScalar::Uint(x) => Ok(x.clone() as i64),
-            DmapScalar::Ulong(x) => Ok(x.clone() as i64),
-            DmapScalar::Float(x) => Ok(x.clone() as i64),
-            DmapScalar::Double(x) => Ok(x.clone() as i64),
+            DmapScalar::Char(x) => Ok(x as i64),
+            DmapScalar::Short(x) => Ok(x as i64),
+            DmapScalar::Int(x) => Ok(x as i64),
+            DmapScalar::Long(x) => Ok(x),
+            DmapScalar::Uchar(x) => Ok(x as i64),
+            DmapScalar::Ushort(x) => Ok(x as i64),
+            DmapScalar::Uint(x) => Ok(x as i64),
+            DmapScalar::Ulong(x) => Ok(x as i64),
+            DmapScalar::Float(x) => Ok(x as i64),
+            DmapScalar::Double(x) => Ok(x as i64),
             DmapScalar::String(x) => Err(DmapError::InvalidScalar(format!(
                 "Unable to convert {x} to i64"
             ))),
         }
     }
 }
-impl TryFrom<&DmapScalar> for f32 {
+impl TryFrom<DmapScalar> for f32 {
     type Error = DmapError;
-    fn try_from(value: &DmapScalar) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: DmapScalar) -> std::result::Result<Self, Self::Error> {
         match value {
-            DmapScalar::Char(x) => Ok(x.clone() as f32),
-            DmapScalar::Short(x) => Ok(x.clone() as f32),
-            DmapScalar::Int(x) => Ok(x.clone() as f32),
-            DmapScalar::Long(x) => Ok(x.clone() as f32),
-            DmapScalar::Uchar(x) => Ok(x.clone() as f32),
-            DmapScalar::Ushort(x) => Ok(x.clone() as f32),
-            DmapScalar::Uint(x) => Ok(x.clone() as f32),
-            DmapScalar::Ulong(x) => Ok(x.clone() as f32),
-            DmapScalar::Float(x) => Ok(x.clone()),
-            DmapScalar::Double(x) => Ok(x.clone() as f32),
+            DmapScalar::Char(x) => Ok(x as f32),
+            DmapScalar::Short(x) => Ok(x as f32),
+            DmapScalar::Int(x) => Ok(x as f32),
+            DmapScalar::Long(x) => Ok(x as f32),
+            DmapScalar::Uchar(x) => Ok(x as f32),
+            DmapScalar::Ushort(x) => Ok(x as f32),
+            DmapScalar::Uint(x) => Ok(x as f32),
+            DmapScalar::Ulong(x) => Ok(x as f32),
+            DmapScalar::Float(x) => Ok(x),
+            DmapScalar::Double(x) => Ok(x as f32),
             DmapScalar::String(x) => Err(DmapError::InvalidScalar(format!(
                 "Unable to convert {x} to f32"
             ))),
         }
     }
 }
-impl TryFrom<&DmapScalar> for f64 {
+impl TryFrom<DmapScalar> for f64 {
     type Error = DmapError;
-    fn try_from(value: &DmapScalar) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: DmapScalar) -> std::result::Result<Self, Self::Error> {
         match value {
-            DmapScalar::Char(x) => Ok(x.clone() as f64),
-            DmapScalar::Short(x) => Ok(x.clone() as f64),
-            DmapScalar::Int(x) => Ok(x.clone() as f64),
-            DmapScalar::Long(x) => Ok(x.clone() as f64),
-            DmapScalar::Uchar(x) => Ok(x.clone() as f64),
-            DmapScalar::Ushort(x) => Ok(x.clone() as f64),
-            DmapScalar::Uint(x) => Ok(x.clone() as f64),
-            DmapScalar::Ulong(x) => Ok(x.clone() as f64),
-            DmapScalar::Float(x) => Ok(x.clone() as f64),
-            DmapScalar::Double(x) => Ok(x.clone()),
+            DmapScalar::Char(x) => Ok(x as f64),
+            DmapScalar::Short(x) => Ok(x as f64),
+            DmapScalar::Int(x) => Ok(x as f64),
+            DmapScalar::Long(x) => Ok(x as f64),
+            DmapScalar::Uchar(x) => Ok(x as f64),
+            DmapScalar::Ushort(x) => Ok(x as f64),
+            DmapScalar::Uint(x) => Ok(x as f64),
+            DmapScalar::Ulong(x) => Ok(x as f64),
+            DmapScalar::Float(x) => Ok(x as f64),
+            DmapScalar::Double(x) => Ok(x),
             DmapScalar::String(x) => Err(DmapError::InvalidScalar(format!(
                 "Unable to convert {x} to f64"
+            ))),
+        }
+    }
+}
+impl TryFrom<DmapScalar> for String {
+    type Error = DmapError;
+    fn try_from(value: DmapScalar) -> std::result::Result<Self, Self::Error> {
+        match value {
+            DmapScalar::String(x) => Ok(x),
+            x => Err(DmapError::InvalidScalar(format!(
+                "Unable to convert {x} to String"
             ))),
         }
     }


### PR DESCRIPTION
## Features
* Updated the permissions so that files are appended to with the `write_[type]()` functions.
* Expose new `read_[type]` functions (e.g., `read_rawacf()`) in Rust library, for convenience
* Adds more conversion traits to/from `DmapScalar`, `DmapVec`, and `DmapField` for user convenience. Essentially, you can convert the types that go into any of these infallibly (i.e. they implement `From<T>`), and convert back fallibly (i.e. `TryFrom<Dmap[...]> for T` is implemented for types within `Dmap[...]`).