### PR TITLE
Improved error messages

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,7 @@ pub enum DmapError {
 
     /// Errors when reading in multiple records
     #[error("First error: {1}\nRecords with errors: {0:?}")]
-    BadRecords(Vec<usize>, String)
+    BadRecords(Vec<usize>, String),
 }
 
 impl From<DmapError> for PyErr {

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,10 @@ pub enum DmapError {
     /// Error interpreting data as a valid DMAP vector.
     #[error("{0}")]
     InvalidVector(String),
+
+    /// Errors when reading in multiple records
+    #[error("First error: {1}\nRecords with errors: {0:?}")]
+    BadRecords(Vec<usize>, String)
 }
 
 impl From<DmapError> for PyErr {

--- a/src/formats/dmap.rs
+++ b/src/formats/dmap.rs
@@ -58,11 +58,11 @@ pub trait Record<'a>:
                 Err(e) => {
                     dmap_errors.push(e);
                     bad_recs.push(i);
-                },
+                }
             }
         }
         if dmap_errors.len() > 0 {
-            return Err(DmapError::BadRecords(bad_recs, dmap_errors[0].to_string()))
+            return Err(DmapError::BadRecords(bad_recs, dmap_errors[0].to_string()));
         }
         Ok(dmap_records)
     }

--- a/src/formats/dmap.rs
+++ b/src/formats/dmap.rs
@@ -50,13 +50,20 @@ pub trait Record<'a>:
         );
 
         let mut dmap_records: Vec<Self> = vec![];
+        let mut bad_recs: Vec<usize> = vec![];
+        let mut dmap_errors: Vec<DmapError> = vec![];
         for (i, rec) in dmap_results.into_iter().enumerate() {
-            dmap_records.push(match rec {
-                Err(e) => Err(DmapError::InvalidRecord(format!("{e}: record {i}")))?,
-                Ok(x) => x,
-            });
+            match rec {
+                Ok(x) => dmap_records.push(x),
+                Err(e) => {
+                    dmap_errors.push(e);
+                    bad_recs.push(i);
+                },
+            }
         }
-
+        if dmap_errors.len() > 0 {
+            return Err(DmapError::BadRecords(bad_recs, dmap_errors[0].to_string()))
+        }
         Ok(dmap_records)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,8 @@ where
             });
     if !errors.is_empty() {
         Err(DmapError::BadRecords(
-            errors.iter().map(|(i, _)| *i).collect(), errors[0].1.to_string()
+            errors.iter().map(|(i, _)| *i).collect(),
+            errors[0].1.to_string(),
         ))?
     }
     bytes.par_extend(rec_bytes.into_par_iter().flatten());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,9 +125,9 @@ where
                 },
             });
     if !errors.is_empty() {
-        Err(DmapError::InvalidRecord(format!(
-            "Corrupted records: {errors:?}"
-        )))?
+        Err(DmapError::BadRecords(
+            errors.iter().map(|(i, _)| *i).collect(), errors[0].1.to_string()
+        ))?
     }
     bytes.par_extend(rec_bytes.into_par_iter().flatten());
     write_to_file(bytes, outfile)?;


### PR DESCRIPTION
Improved the error messages for file-level I/O functions.

Prints the error message of the first record that fails, as well as a list of all record indices that failed.

## Example

```
(dmap) remington@sdc-eng2~/dmap$ python3
Python 3.9.15 (main, Oct 28 2022, 17:28:38) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import dmap
>>> dmap.read_fitacf("tests/test_files/test.rawacf")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: First error: Unsupported fields ["rawacf.revision.major", "rawacf.revision.minor", "thr", "acfd", "xcfd"], fields supported are ["radar.revision.major", "radar.revision.minor", "origin.code", "origin.time", "origin.command", "cp", "stid", "time.yr", "time.mo", "time.dy", "time.hr", "time.mt", "time.sc", "time.us", "txpow", "nave", "atten", "lagfr", "smsep", "ercod", "stat.agc", "stat.lopwr", "noise.search", "noise.mean", "channel", "bmnum", "bmazm", "scan", "offset", "rxrise", "intt.sc", "intt.us", "txpl", "mpinc", "mppul", "mplgs", "nrang", "frang", "rsep", "xcf", "tfreq", "mxpwr", "lvmax", "combf", "fitacf.revision.major", "fitacf.revision.minor", "noise.sky", "noise.lag0", "noise.vel", "mplgexs", "ifmode", "algorithm", "tdiff", "ptab", "ltab", "pwr0", "slist", "nlag", "qflg", "gflg", "p_l", "p_l_e", "p_s", "p_s_e", "v", "v_e", "w_l", "w_l_e", "w_s", "w_s_e", "sd_l", "sd_s", "sd_phi", "x_qflg", "x_gflg", "x_p_l", "x_p_l_e", "x_p_s", "x_p_s_e", "x_v", "x_v_e", "x_w_l", "x_w_l_e", "x_w_s", "x_w_s_e", "phi0", "phi0_e", "elv", "elv_fitted", "elv_error", "elv_low", "elv_high", "x_sd_l", "x_sd_s", "x_sd_phi"]
Records with errors: [0, 1]
```