### PR TITLE
Release: v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dmap"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.63.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dmap"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.63.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "darn-dmap"
-version = "0.2.1"
+version = "0.3.0"
 requires-python = ">=3.8"
 authors = [
     { name = "Remington Rohel" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "darn-dmap"
-version = "0.3.0"
+version = "0.4.0"
 requires-python = ">=3.8"
 authors = [
     { name = "Remington Rohel" }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -2,11 +2,6 @@ use std::io::{Chain, Cursor, Error, Read};
 
 /// Detects bz2 compression on the input `stream`. Returns a reader
 /// which includes all data from `stream`.
-///
-/// ## Example
-/// ```
-
-/// ```
 pub(crate) fn detect_bz2<T>(mut stream: T) -> Result<(bool, Chain<Cursor<[u8; 3]>, T>), Error>
 where
     T: for<'a> Read,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -92,6 +92,14 @@ macro_rules! make_test {
                 // Clean up tempfile
                 remove_file(&tempfile).expect("Unable to delete tempfile");
             }
+
+            #[test]
+            fn [< test_ $record_type _sniff >] () {
+                let filename: PathBuf = PathBuf::from(format!("tests/test_files/test.{}", stringify!($record_type)));
+                let data = [< $record_type:camel Record >]::sniff_file(&filename).expect("Unable to sniff file");
+                let all_recs = [< $record_type:camel Record >]::read_file(&filename).expect("Unable to read file");
+                assert_eq!(data, all_recs[0])
+            }
         }
     };
 }


### PR DESCRIPTION
# Features
* Auto-detection of bz2 compression using the bz2 magic signature of "BZh" at the start of the stream
* Updated API for easier importing of members (e.g. `use dmap::FitacfRecord` instead of `use dmap::formats::fitacf::FitacfRecord`)
* Extensive unit testing additions to `types.rs`, `compression.rs`, and `record.rs`.