### PR TITLE
Partial decompression when reading only first record

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -58,6 +58,36 @@ pub(crate) fn create_stream<'b>(
     }
 }
 
+/// Read the first record from a stream.
+///
+/// Will only decompress the first chunks of a bzip2-compressed stream, until a full record
+/// is decompressed.
+pub(crate) fn grab_first_record(mut dmap_data: impl Read) -> Result<Parser, DmapError> {
+    let mut stream = create_stream(&mut dmap_data)?;
+    let mut bytes = [0u8; 100000];  // arbitrarily chosen size
+    let chunk_size = bytes.len();
+    let mut rec_bytes = vec![];
+    let mut rec_size: Option<usize> = None;
+    loop {
+        let bytes_read = stream.read(&mut bytes)?;
+        if bytes_read == 0 {
+            return Err(DmapError::InvalidRecord("Could not extract the first record".to_string()))
+        }
+        if bytes_read <= chunk_size {
+            rec_bytes.extend(bytes[0..bytes_read].iter());
+        }
+        if rec_bytes.len() >= 8 {
+            rec_size = Some(i32::from_le_bytes(rec_bytes[4..8].try_into().unwrap()) as usize); // advance 4 bytes, skipping the "code" field
+        }
+        if let Some(x) = rec_size {
+            if rec_bytes.len() >= x {
+                let parser = Parser::new(rec_bytes[0..x].to_vec());
+                return Ok(parser)
+            }
+        }
+    }
+}
+
 /// Parses `dmap_data` into discrete chunks, each corresponding to a DMAP record.  
 pub(crate) fn split_into_slices(mut dmap_data: impl Read) -> Result<Vec<Parser>, DmapError> {
     let mut buffer: Vec<u8> = vec![];

--- a/src/record.rs
+++ b/src/record.rs
@@ -3,7 +3,7 @@
 use crate::convenience::split_results;
 use crate::error::DmapError;
 use crate::io::{self};
-use crate::io::{create_stream, slice_stream_lax, split_into_slices};
+use crate::io::{create_stream, grab_first_record, slice_stream_lax, split_into_slices};
 use crate::types::{DmapField, DmapType, DmapVec, Fields};
 use indexmap::IndexMap;
 use itertools::izip;
@@ -46,6 +46,16 @@ pub trait Record<'a>:
         Self: Sized,
         Self: Send,
     {
+        // Special case, handle differently so the whole stream does need to be decompressed if bz2
+        // compression is detected.
+        if indices.len() == 1 && indices[0] == 0 {
+            let mut parser = grab_first_record(dmap_data)?;
+            let rec = parser.parse_record::<Self>().map_err(|e| {
+                DmapError::InvalidRecord(format!("Record 0: {}", e.to_string()))
+            })?;
+            return Ok(vec![rec])
+        }
+
         let mut slices = split_into_slices(dmap_data)?;
         let num_recs = slices.len();
         let mut records_read = vec![];
@@ -79,6 +89,16 @@ pub trait Record<'a>:
         Self: Sized,
         Self: Send,
     {
+        // Special case, handle differently so the whole stream does need to be decompressed if bz2
+        // compression is detected.
+        if indices.len() == 1 && indices[0] == 0 {
+            let mut parser = grab_first_record(dmap_data)?;
+            match parser.parse_record::<Self>() {
+                Ok(x) => { return Ok((vec![x], None)) },
+                Err(_) => { return Ok((vec![], Some(0))) }
+            }
+        }
+
         let mut buffer: Vec<u8> = vec![];
         let mut dmap_records: Vec<Self> = vec![];
 
@@ -167,6 +187,16 @@ pub trait Record<'a>:
         Self: Sized,
         Self: Send,
     {
+        // Special case, handle differently so the whole stream does need to be decompressed if bz2
+        // compression is detected.
+        if indices.len() == 1 && indices[0] == 0 {
+            let mut parser = grab_first_record(dmap_data)?;
+            let rec = parser.parse_metadata::<Self>().map_err(|e| {
+                DmapError::InvalidRecord(format!("Record 0: {}", e.to_string()))
+            })?;
+            return Ok(vec![rec])
+        }
+
         let mut slices = split_into_slices(dmap_data)?;
         let mut dmap_results: Vec<IndexMap<String, DmapField>> = vec![];
 


### PR DESCRIPTION
* Only decompresses the beginning of a bzip2'd stream if only the first record is requested; else, decompresses the entire stream.

Tested with a 2.2 GB compressed RAWACF file, reduces the read time for the first record from ~114 seconds to 0.036 seconds.